### PR TITLE
switch to nightly rust toolchain

### DIFF
--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -1,5 +1,5 @@
-mod state;
-mod types;
+pub mod state;
+pub mod types;
 
 use self::state::{StateError, TokenState};
 use crate::method::{MethodCallError, MethodCaller};

--- a/fil_fungible_token/src/token/state.rs
+++ b/fil_fungible_token/src/token/state.rs
@@ -44,7 +44,7 @@ pub enum StateError {
 type Result<T> = std::result::Result<T, StateError>;
 
 /// Token state IPLD structure
-#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Clone, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct TokenState {
     /// Total supply of token
     #[serde(with = "bigint_ser")]

--- a/fvm_dispatch/src/hash.rs
+++ b/fvm_dispatch/src/hash.rs
@@ -28,7 +28,7 @@ pub struct MethodResolver<T: Hasher> {
     hasher: T,
 }
 
-#[derive(Error, PartialEq, Debug)]
+#[derive(Error, PartialEq, Eq, Debug)]
 pub enum MethodNameErr {
     #[error("empty method name provided")]
     EmptyString,
@@ -38,7 +38,7 @@ pub enum MethodNameErr {
     IndeterminableId,
 }
 
-#[derive(Error, PartialEq, Debug)]
+#[derive(Error, PartialEq, Eq, Debug)]
 pub enum IllegalNameErr {
     #[error("method name doesn't start with capital letter")]
     NotCapitalStart,

--- a/fvm_dispatch/src/message.rs
+++ b/fvm_dispatch/src/message.rs
@@ -12,7 +12,7 @@ pub struct MethodMessenger<T: Hasher> {
     method_resolver: MethodResolver<T>,
 }
 
-#[derive(Error, PartialEq, Debug)]
+#[derive(Error, PartialEq, Eq, Debug)]
 pub enum MethodMessengerError {
     #[error("error when calculating method name: `{0}`")]
     MethodName(#[from] MethodNameErr),

--- a/fvm_dispatch_tools/src/main.rs
+++ b/fvm_dispatch_tools/src/main.rs
@@ -38,16 +38,14 @@ fn main() {
         let mut line = String::new();
 
         loop {
-            match handle.read_line(&mut line) {
-                Ok(0) => break,
-                Ok(_) => {
-                    let method_name = line.trim().to_string();
-                    let method_number = resolver.method_number(&method_name).unwrap();
-                    println!("{}", method_number);
-                    line.clear();
-                }
-                Err(err) => panic!("error parsing stdin {:?}", err),
+            let num_read = handle.read_line(&mut line).unwrap();
+            if num_read == 0 {
+                break;
             }
+            let method_name = line.trim().to_string();
+            let method_number = resolver.method_number(&method_name).unwrap();
+            println!("{}", method_number);
+            line.clear();
         }
 
         exit(0);

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-stable
+nightly


### PR DESCRIPTION
If we want to build FVM actors in this same repo, it looks like we will need to switch to a nightly toolchain

In CI we will probably need to use [rust-actions](https://github.com/marketplace/actions/rust-toolchain) to get the right toolchain installed

Still WIP: but not a draft to get PR checks to run

