### PR TITLE
fix mint receiver hook

### DIFF
--- a/fil_fungible_token/src/receiver/types.rs
+++ b/fil_fungible_token/src/receiver/types.rs
@@ -1,7 +1,8 @@
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_shared::bigint::bigint_ser;
-use fvm_shared::{address::Address, econ::TokenAmount};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::ActorID;
 
 /// Standard interface for an actor that wishes to receive FRC-XXX tokens
 pub trait FrcXXXTokenReceiver {
@@ -15,9 +16,14 @@ pub trait FrcXXXTokenReceiver {
     fn token_received(params: TokenReceivedParams);
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct TokenReceivedParams {
-    pub sender: Address,
+    /// Address of the sender or operator that initiated the transfer
+    pub sender: ActorID,
+    /// The account that the tokens are being pulled from (the token actor address itself for mint)
+    pub from: ActorID,
+    /// The account that the tokens are being sent to (the receiver address)
+    pub to: ActorID,
     #[serde(with = "bigint_ser")]
     pub value: TokenAmount,
     pub data: RawBytes,

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 
 use fvm_ipld_encoding::Error as IpldError;
 use fvm_ipld_encoding::RawBytes;
-use fvm_sdk::{actor, send, sys::ErrorNumber};
+use fvm_sdk::{actor, message, send, sys::ErrorNumber};
 use fvm_shared::error::ExitCode;
 use fvm_shared::receipt::Receipt;
+use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{address::Address, econ::TokenAmount, ActorID};
 use num_traits::Zero;
@@ -27,11 +28,17 @@ pub enum MessagingError {
 
 /// An abstraction used to send messages to other actors
 pub trait Messaging {
-    /// Call the receiver hook on a given actor, specifying the amount of tokens pending to be sent
-    /// and the sender and receiver
-    ///
-    /// Returns true if the receiver hook is called and exits without error, else returns false
-    fn call_receiver_hook(&self, to: &Address, params: &TokenReceivedParams) -> Result<Receipt>;
+    /// Returns the address of the current actor as an ActorID
+    fn actor_id(&self) -> ActorID;
+
+    /// Sends a message to an actor
+    fn send(
+        &self,
+        to: &Address,
+        method: MethodNum,
+        params: &RawBytes,
+        value: &TokenAmount,
+    ) -> Result<Receipt>;
 
     /// Resolves the given address to its ID address form
     ///
@@ -44,21 +51,29 @@ pub trait Messaging {
     fn initialize_account(&self, address: &Address) -> Result<ActorID>;
 }
 
+// TODO: use fvm_dispatch here (when it supports compile time method resolution)
+// TODO: ^^ necessitates determining conventional method names for receiver hooks
+// currently, the method number comes from taking the name as "TokensReceived" and applying
+// the transformation described in https://github.com/filecoin-project/FIPs/pull/399
+pub const RECEIVER_HOOK_METHOD_NUM: u64 = 1361519036;
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FvmMessenger {}
 
 impl Messaging for FvmMessenger {
-    fn call_receiver_hook(&self, to: &Address, params: &TokenReceivedParams) -> Result<Receipt> {
-        // TODO: use fvm_dispatch here (when it supports compile time method resolution)
-        // TODO: ^^ necessitates determining conventional method names for receiver hooks
+    fn actor_id(&self) -> ActorID {
+        message::receiver()
+    }
 
-        // currently, the method number comes from taking the name as "TokensReceived" and applying
-        // the transformation described in https://github.com/filecoin-project/FIPs/pull/399
-        const METHOD_NUM: u64 = 1361519036;
-
+    fn send(
+        &self,
+        to: &Address,
+        method: MethodNum,
+        params: &RawBytes,
+        value: &TokenAmount,
+    ) -> Result<Receipt> {
         let params = RawBytes::new(fvm_ipld_encoding::to_vec(&params)?);
-
-        Ok(send::send(to, METHOD_NUM, params, TokenAmount::zero())?)
+        Ok(send::send(to, method, params, value.clone())?)
     }
 
     fn resolve_id(&self, address: &Address) -> Result<ActorID> {
@@ -76,23 +91,12 @@ impl Messaging for FvmMessenger {
 
 /// A fake method caller
 ///
-/// # call_receiver_hook
-/// If call_receiver_hook is called with an empty data array, it will return true.
-/// If call_receiver_hook is called with a non-empty data array, it will return false.
-///
-/// # resolve_id
-/// If Address is id-address or secp-address, it resolves by returing FAKE_RESOLVED_ID
-/// If Address is actor-address or bls-address, it returns an error simulating an uninitialised address
-///
-/// # initialise_account
-/// Simulates the initialisation of an account
-/// - ID, SECP addresses panic as they should not be called given that resolve_id gave back an ActorID
-/// - BLS addresses give back FAKE_INITIALIZED_ID
-/// - Actor addresses are uninitialised and give back an error
 #[derive(Debug)]
 pub struct FakeMessenger {
     pub last_hook: RefCell<Option<TokenReceivedParams>>,
     address_resolver: RefCell<FakeAddressResolver>,
+    actor_id: ActorID,
+    abort_next_send: RefCell<bool>,
 }
 
 impl FakeMessenger {
@@ -101,30 +105,47 @@ impl FakeMessenger {
     /// first_usable_actor_id is the first ActorID that has not been already allocated to an address
     /// i.e. in test fixtures where it may be useful to have statically allocated ID addresses, they
     /// should all have an ActorID strictly below first_usable_actor_id
-    pub fn new(first_usable_actor_id: ActorID) -> Self {
+    pub fn new(actor_id: ActorID, first_usable_actor_id: ActorID) -> Self {
         Self {
+            actor_id,
             address_resolver: RefCell::new(FakeAddressResolver::new(first_usable_actor_id)),
             last_hook: Default::default(),
+            abort_next_send: RefCell::new(false),
         }
+    }
+
+    pub fn abort_next_send(&mut self) {
+        self.abort_next_send.replace(true);
     }
 }
 
 impl Messaging for FakeMessenger {
-    fn call_receiver_hook(&self, _to: &Address, params: &TokenReceivedParams) -> Result<Receipt> {
-        self.last_hook.borrow_mut().replace(params.clone());
-        if params.data.is_empty() {
-            Ok(Receipt {
-                exit_code: ExitCode::OK,
-                return_data: RawBytes::new(params.data.to_vec()),
+    fn actor_id(&self) -> ActorID {
+        self.actor_id
+    }
+
+    fn send(
+        &self,
+        _to: &Address,
+        method: MethodNum,
+        params: &RawBytes,
+        _value: &TokenAmount,
+    ) -> Result<Receipt> {
+        if *self.abort_next_send.borrow() {
+            self.abort_next_send.replace(false);
+            return Ok(Receipt {
+                exit_code: ExitCode::USR_UNSPECIFIED,
                 gas_used: 0,
-            })
-        } else {
-            Ok(Receipt {
-                exit_code: ExitCode::SYS_INVALID_RECEIVER,
-                return_data: RawBytes::new(params.data.to_vec()),
-                gas_used: 0,
-            })
+                return_data: Default::default(),
+            });
         }
+
+        if method == RECEIVER_HOOK_METHOD_NUM {
+            let hook_params = params.deserialize().unwrap();
+            self.last_hook.borrow_mut().replace(hook_params);
+        }
+
+        Ok(Receipt { exit_code: ExitCode::OK, return_data: Default::default(), gas_used: 0 })
     }
 
     fn resolve_id(&self, address: &Address) -> Result<ActorID> {
@@ -298,7 +319,7 @@ mod test_fake_messenger {
     /// The resolution of addresses is tested in the test_address_resolver module
     #[test]
     fn it_resolves_addresses_with_fake_address_resolver() {
-        let m = FakeMessenger::new(1);
+        let m = FakeMessenger::new(0, 1);
         let secp_1 = &secp_address(1);
         let secp_2 = &secp_address(2);
         let bls_1 = &bls_address(1);

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -99,6 +99,9 @@ pub struct FakeMessenger {
     abort_next_send: RefCell<bool>,
 }
 
+/// A mocked messenger that can be used to interact with other Actors
+///
+/// Can be used to test behaviour when other Actors abort when handling messages
 impl FakeMessenger {
     /// Creates a new FakeMessenger with a given set of initialized accounts
     ///
@@ -157,6 +160,8 @@ impl Messaging for FakeMessenger {
     }
 }
 
+/// A fake address resolver that keeps track of addresses that keeps track of which addresses have
+/// been initialised and their corresponding IDs
 #[derive(Debug)]
 pub struct FakeAddressResolver {
     next_actor_id: ActorID,

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -603,6 +603,18 @@ mod test {
         // mint zero
         token.mint(TOKEN_ACTOR, ALICE, &TokenAmount::zero(), &[]).unwrap();
 
+        // check receiver hook was called with correct shape
+        assert_last_msg_eq(
+            &token.msg,
+            TokenReceivedParams {
+                sender: TOKEN_ACTOR.id().unwrap(),
+                data: RawBytes::default(),
+                from: TOKEN_ACTOR.id().unwrap(),
+                to: ALICE.id().unwrap(),
+                value: TokenAmount::zero(),
+            },
+        );
+
         // state remained unchanged
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::zero());
         assert_eq!(token.total_supply(), TokenAmount::from(1_000_000));


### PR DESCRIPTION
Construction of the TokenReceiverHook params is now performed in the Token library rather than in the injected layer and tested