### PR TITLE
Re-organise dispatch and macro crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "fvm_dispatch",
+    "fvm_dispatch/hasher",
     "fvm_dispatch/macros",
     "fvm_dispatch/macros/example",
     "fvm_dispatch_tools",

--- a/fvm_dispatch/Cargo.toml
+++ b/fvm_dispatch/Cargo.toml
@@ -3,11 +3,10 @@ name = "fvm_dispatch"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-hasher = { path = "hasher" }
 fvm_ipld_encoding = { version = "0.2.2" }
 fvm_sdk = { version = "1.0.0" }
 fvm_shared = { version = "0.8.0" }
+hasher = { path = "hasher" }
+macros = { path = "macros" }
 thiserror = { version = "1.0.31" }

--- a/fvm_dispatch/Cargo.toml
+++ b/fvm_dispatch/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+hasher = { path = "hasher" }
 fvm_ipld_encoding = { version = "0.2.2" }
 fvm_sdk = { version = "1.0.0" }
 fvm_shared = { version = "0.8.0" }

--- a/fvm_dispatch/hasher/Cargo.toml
+++ b/fvm_dispatch/hasher/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hasher"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fvm_shared = { version = "0.8.0" }
+thiserror = { version = "1.0.31" }
+
+fvm_sdk = { version = "1.0.0", optional = true }
+
+[features]
+default = ["dep:fvm_sdk"]
+no_sdk = [] # avoid dependence on fvm_sdk (for proc macro and similar purposes)

--- a/fvm_dispatch/hasher/src/hash.rs
+++ b/fvm_dispatch/hasher/src/hash.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "no_sdk"))]
 use fvm_sdk::crypto;
 
 /// Minimal interface for a hashing function
@@ -17,14 +17,14 @@ pub trait Hasher {
 pub struct Blake2bSyscall {}
 
 impl Hasher for Blake2bSyscall {
-    // fvm_sdk syscalls only work for WASM targets
-    #[cfg(target_family = "wasm")]
+    // fvm_sdk dependence can be removed using no_sdk feature
+    #[cfg(not(feature = "no_sdk"))]
     fn hash(&self, bytes: &[u8]) -> Vec<u8> {
         crypto::hash_blake2b(bytes).try_into().unwrap()
     }
 
     // stub version for non-wasm targets (eg: proc macros running on x86_64)
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "no_sdk")]
     #[allow(unused_variables)]
     fn hash(&self, bytes: &[u8]) -> Vec<u8> {
         unimplemented!();

--- a/fvm_dispatch/hasher/src/lib.rs
+++ b/fvm_dispatch/hasher/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod hash;

--- a/fvm_dispatch/macros/Cargo.toml
+++ b/fvm_dispatch/macros/Cargo.toml
@@ -8,11 +8,10 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-fvm_dispatch = { version = "0.1.0", path = "../" }
+hasher = { path = "../hasher", features = ["no_sdk"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
-thiserror = { version = "1.0.31" }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/fvm_dispatch/macros/Cargo.toml
+++ b/fvm_dispatch/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_dispatch_macros"
+name = "macros"
 version = "0.1.0"
 edition = "2021"
 

--- a/fvm_dispatch/macros/example/Cargo.toml
+++ b/fvm_dispatch/macros/example/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_dispatch = { version = "0.1.0", path = "../../../fvm_dispatch" }
-fvm_dispatch_macros = { path = ".." }
+macros = { path = ".." }

--- a/fvm_dispatch/macros/example/src/main.rs
+++ b/fvm_dispatch/macros/example/src/main.rs
@@ -1,4 +1,4 @@
-use fvm_dispatch_macros::method_hash;
+use macros::method_hash;
 
 fn main() {
     let str_hash = method_hash!("Method");

--- a/fvm_dispatch/macros/src/hash.rs
+++ b/fvm_dispatch/macros/src/hash.rs
@@ -1,5 +1,5 @@
 use blake2b_simd::blake2b;
-use fvm_dispatch::hash::Hasher;
+use hasher::hash::Hasher;
 
 pub struct Blake2bHasher {}
 impl Hasher for Blake2bHasher {

--- a/fvm_dispatch/macros/src/lib.rs
+++ b/fvm_dispatch/macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 
-use fvm_dispatch::hash::MethodResolver;
+use hasher::hash::MethodResolver;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{parse_macro_input, LitStr, Result};

--- a/fvm_dispatch/macros/tests/build-success.rs
+++ b/fvm_dispatch/macros/tests/build-success.rs
@@ -1,4 +1,4 @@
-use fvm_dispatch_macros::method_hash;
+use macros::method_hash;
 
 fn main() {
     let str_hash = method_hash!("Method");

--- a/fvm_dispatch/macros/tests/naming/empty-name-string.rs
+++ b/fvm_dispatch/macros/tests/naming/empty-name-string.rs
@@ -1,4 +1,4 @@
-use fvm_dispatch_macros::method_hash;
+use macros::method_hash;
 
 fn main() {
 	// this should panic due to empty string

--- a/fvm_dispatch/macros/tests/naming/illegal-chars.rs
+++ b/fvm_dispatch/macros/tests/naming/illegal-chars.rs
@@ -1,4 +1,4 @@
-use fvm_dispatch_macros::method_hash;
+use macros::method_hash;
 
 fn main() {
 	// should panic because the name contains illegal chars

--- a/fvm_dispatch/macros/tests/naming/missing-name.rs
+++ b/fvm_dispatch/macros/tests/naming/missing-name.rs
@@ -1,4 +1,4 @@
-use fvm_dispatch_macros::method_hash;
+use macros::method_hash;
 
 fn main() {
 	// should panic because no string or identifier provided

--- a/fvm_dispatch/macros/tests/naming/non-capital-start.rs
+++ b/fvm_dispatch/macros/tests/naming/non-capital-start.rs
@@ -1,4 +1,4 @@
-use fvm_dispatch_macros::method_hash;
+use macros::method_hash;
 
 fn main() {
 	// should panic because the name starts with non-capital letter

--- a/fvm_dispatch/src/lib.rs
+++ b/fvm_dispatch/src/lib.rs
@@ -1,4 +1,6 @@
-pub mod hash;
+pub use hasher;
+pub use hasher::hash;
+
 pub mod message;
 
 #[cfg(test)]

--- a/fvm_dispatch/src/lib.rs
+++ b/fvm_dispatch/src/lib.rs
@@ -1,5 +1,6 @@
 pub use hasher;
 pub use hasher::hash;
+pub use macros::method_hash;
 
 pub mod message;
 


### PR DESCRIPTION
Noisy diffs in this one (but the commits cover one change each and will be easier to review) because it moves and renames a bunch of things.

- hashing moved out into its own (sub-)crate
- proc macro crate also renamed to become a (sub-)crate
- macro and hashing stuff transparently re-exported through `fvm_dispatch`

This paves the way for declarative (`macro_rules!`) and proc macros to (appear to) live in the same crate. Also improves build times somewhat as the macro crate depends on the hashing crate directly instead of the full `fvm_dispatch`, and avoids pulling in `fvm_sdk` entirely with a `no_sdk` feature flag.

Anything using the hashing functions from `fvm_dispatch` will continue to work as before, while the method hashing macro should now be available as `fvm_dispatch::method_hash`