### PR TITLE
Method match macro and example actor

### DIFF
--- a/.github/workflows/check-main.yml
+++ b/.github/workflows/check-main.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Build
         run: make check-build
 
-      - name: Test
-        run: make test
+      - name: Test Actors
+        run: make test-actors
+
+      - name: Test Libraries
+        run: make test-coverage
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off'

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Build
         run: make check-build
 
-      - name: Test
-        run: make test
+      - name: Test Actors
+        run: make test-actors
+
+      - name: Test Libraries
+        run: make test-coverage
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "dispatch_examples/greeter",
     "fvm_dispatch",
     "fvm_dispatch/hasher",
     "fvm_dispatch/macros",

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,19 @@ check: install-toolchain
 check-build: check
 	cargo build --workspace
 
+# run all tests, this will not work if using RUSTFLAGS="-Zprofile" to generate profile info or coverage reports
+# as any WASM targets will fail to build
 test: install-toolchain
 	cargo test
+
+# tests excluding actors so we can generate coverage reports during CI build
+# WASM targets such as actors do not support this so are excluded
+test-coverage: install-toolchain
+	cargo test --workspace --exclude greeter
+
+# separate actor testing stage to run from CI without coverage support
+test-actors:
+	cargo test --package greeter
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ build: install-toolchain
 
 check: install-toolchain
 	cargo fmt --check
-	cargo clippy --workspace --all-targets --all-features -- -D warnings
+	cargo clippy --workspace -- -D warnings
 
 check-build: check
-	cargo build --workspace --all-targets --all-features
+	cargo build --workspace
 
 test: install-toolchain
 	cargo test

--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "greeter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fvm_dispatch = { path = "../../fvm_dispatch" }
+fvm_ipld_blockstore = "0.1.1"
+fvm_ipld_encoding = "0.2.2"
+fvm_sdk = { version = "1.0.0" }
+fvm_shared = { version = "0.8.0" }
+
+[dev-dependencies]
+cid = { version = "0.8.5", default-features = false }
+fvm = { version = "~1.1.0", default-features = false }
+fvm_integration_tests = "0.1.0"
+
+[build-dependencies]
+wasm-builder = "3.0"

--- a/dispatch_examples/greeter/README.md
+++ b/dispatch_examples/greeter/README.md
@@ -1,0 +1,8 @@
+# Greeter example
+A very basic "greeter" actor and an integration test to run it locally. Implements a `Constructor` and a single `Greet` method that takes a string containing a name and returns a greeting.
+
+## To run
+`cargo build` to build the actor code
+`cargo test` to run it in an integration test (using `fvm_integration_tests`)
+
+Run with `cargo test -- --nocapture` to see the greeting output

--- a/dispatch_examples/greeter/build.rs
+++ b/dispatch_examples/greeter/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    use wasm_builder::WasmBuilder;
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .append_to_rust_flags("-Ctarget-feature=+crt-static")
+        .append_to_rust_flags("-Cpanic=abort")
+        .append_to_rust_flags("-Coverflow-checks=true")
+        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Copt-level=z")
+        .build()
+}

--- a/dispatch_examples/greeter/src/lib.rs
+++ b/dispatch_examples/greeter/src/lib.rs
@@ -1,0 +1,38 @@
+use fvm_dispatch::match_method;
+use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_sdk as sdk;
+use fvm_shared::error::ExitCode;
+use sdk::NO_DATA_BLOCK_ID;
+
+fn greet(name: &str) -> String {
+    String::from("Hello, ") + name
+}
+
+#[no_mangle]
+fn invoke(input: u32) -> u32 {
+    let method_num = sdk::message::method_number();
+    match_method!(method_num, {
+        "Constructor" => {
+            // this is a stateless actor so constructor does nothing
+            NO_DATA_BLOCK_ID
+        },
+        "Greet" => {
+            // Greet takes a name as a utf8 string
+            // returns "Hello, {name}"
+            let params = sdk::message::params_raw(input).unwrap().1;
+            let params = RawBytes::new(params);
+            let name = params.deserialize::<String>().unwrap();
+
+            let greeting = greet(&name);
+
+            let bytes = fvm_ipld_encoding::to_vec(&greeting).unwrap();
+            sdk::ipld::put_block(DAG_CBOR, bytes.as_slice()).unwrap()
+        },
+        _ => {
+            sdk::vm::abort(
+                ExitCode::USR_ILLEGAL_ARGUMENT.value(),
+                Some("Unknown method number"),
+            );
+        }
+    })
+}

--- a/dispatch_examples/greeter/tests/greet.rs
+++ b/dispatch_examples/greeter/tests/greet.rs
@@ -1,0 +1,78 @@
+use cid::Cid;
+use fvm::executor::{ApplyKind, Executor};
+use fvm_dispatch::method_hash;
+use fvm_integration_tests::tester::{Account, Tester};
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::bigint::Zero;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::message::Message;
+use fvm_shared::state::StateTreeVersion;
+use fvm_shared::version::NetworkVersion;
+
+const DISPATCH_EXAMPLE_WASM: &str = "../../target/debug/wbuild/greeter/greeter.compact.wasm";
+
+#[test]
+fn test_greeter() {
+    let blockstore = MemoryBlockstore::default();
+    let mut tester = Tester::new(NetworkVersion::V15, StateTreeVersion::V4, blockstore).unwrap();
+
+    let wasm_path =
+        std::env::current_dir().unwrap().join(DISPATCH_EXAMPLE_WASM).canonicalize().unwrap();
+    let wasm_bin = std::fs::read(wasm_path).expect("Unable to read file");
+
+    // set up a test environment with user/actor addresses and no initial state
+    let user: [Account; 1] = tester.create_accounts().unwrap();
+    let actor_address = Address::new_id(10000);
+    tester
+        .set_actor_from_bin(&wasm_bin, Cid::default(), actor_address, TokenAmount::zero())
+        .unwrap();
+
+    tester.instantiate_machine().unwrap();
+
+    // call Constructor
+    let message = Message {
+        from: user[0].1,
+        to: actor_address,
+        gas_limit: 99999999,
+        method_num: method_hash!("Constructor"),
+        sequence: 0,
+        ..Message::default()
+    };
+
+    let _ret_val = tester
+        .executor
+        .as_mut()
+        .unwrap()
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    // call Greet for a classic "hello world"
+    let params = RawBytes::serialize(String::from("World!")).unwrap();
+
+    let message = Message {
+        from: user[0].1,
+        to: actor_address,
+        gas_limit: 99999999,
+        method_num: method_hash!("Greet"),
+        sequence: 1,
+        params,
+        ..Message::default()
+    };
+
+    let ret_val = tester
+        .executor
+        .as_mut()
+        .unwrap()
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    // get result
+    let return_data = ret_val.msg_receipt.return_data;
+    let greeting: String = return_data.deserialize().unwrap();
+    // display the result - run `cargo test -- --nocapture` to see output
+    println!("greeting: {}", greeting);
+
+    assert_eq!(greeting, "Hello, World!")
+}

--- a/fvm_dispatch/Cargo.toml
+++ b/fvm_dispatch/Cargo.toml
@@ -10,3 +10,4 @@ fvm_shared = { version = "0.8.0" }
 hasher = { path = "hasher" }
 macros = { path = "macros" }
 thiserror = { version = "1.0.31" }
+

--- a/fvm_dispatch/src/lib.rs
+++ b/fvm_dispatch/src/lib.rs
@@ -2,6 +2,7 @@ pub use hasher;
 pub use hasher::hash;
 pub use macros::method_hash;
 
+pub mod match_method;
 pub mod message;
 
 #[cfg(test)]

--- a/fvm_dispatch/src/match_method.rs
+++ b/fvm_dispatch/src/match_method.rs
@@ -1,0 +1,23 @@
+#[macro_export]
+macro_rules! match_method {
+    ($method:expr, {$($body:tt)*}) => {
+        match_method!{@match $method, {}, $($body)*}
+    };
+    (@match $method:expr, {$($body:tt)*}, $(,)*) => {
+        match $method {
+            $($body)*
+            _ => None // TODO: add a separate rule for user to specify this
+        }
+    };
+    (@match $method:expr, {$($body:tt)*}, $p:literal => $e:expr, $($tail:tt)*) => {
+        match_method! {
+            @match
+            $method,
+            {
+                $($body)*
+                $crate::method_hash!($p) => $e,
+            },
+            $($tail)*
+        }
+    };
+}

--- a/fvm_dispatch/src/match_method.rs
+++ b/fvm_dispatch/src/match_method.rs
@@ -31,3 +31,40 @@ macro_rules! match_method {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn handle_constructor() {
+        let method_num = 1u64; // constructor should always hash to 1
+        let ret = match_method!(method_num, {
+            "Constructor" => Some(1),
+            _ => None,
+        });
+
+        assert_eq!(ret, Some(1));
+    }
+
+    #[test]
+    fn handle_unknown_method() {
+        let method_num = 12345u64; // not a method we know about
+        let ret = match_method!(method_num, {
+            "Constructor" => Some(1),
+            _ => None,
+        });
+
+        assert_eq!(ret, None);
+    }
+
+    #[test]
+    fn handle_user_method() {
+        let method_num = crate::method_hash!("TokensReceived");
+        let ret = match_method!(method_num, {
+            "Constructor" => Some(1),
+            "TokensReceived" => Some(2),
+            _ => None,
+        });
+
+        assert_eq!(ret, Some(2));
+    }
+}

--- a/fvm_dispatch/src/match_method.rs
+++ b/fvm_dispatch/src/match_method.rs
@@ -6,7 +6,6 @@ macro_rules! match_method {
     (@match $method:expr, {$($body:tt)*}, $(,)*) => {
         match $method {
             $($body)*
-            _ => None // TODO: add a separate rule for user to specify this
         }
     };
     (@match $method:expr, {$($body:tt)*}, $p:literal => $e:expr, $($tail:tt)*) => {
@@ -16,6 +15,17 @@ macro_rules! match_method {
             {
                 $($body)*
                 $crate::method_hash!($p) => $e,
+            },
+            $($tail)*
+        }
+    };
+    (@match $method:expr, {$($body:tt)*}, _ => $e:expr, $($tail:tt)*) => {
+        match_method! {
+            @match
+            $method,
+            {
+                $($body)*
+                _ => $e,
             },
             $($tail)*
         }

--- a/fvm_dispatch/src/message.rs
+++ b/fvm_dispatch/src/message.rs
@@ -5,7 +5,7 @@ use fvm_sdk::sys::ErrorNumber;
 use fvm_shared::{address::Address, econ::TokenAmount, receipt::Receipt};
 use thiserror::Error;
 
-use crate::hash::{Hasher, MethodNameErr, MethodResolver}; // fvm_sdk syscalls only work for WASM targets
+use crate::hash::{Hasher, MethodNameErr, MethodResolver};
 
 /// Utility to invoke standard methods on deployed actors
 #[derive(Default)]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2022-05-09


### PR DESCRIPTION
Adds a macro to generate a `match` for method dispatching in an actor's `invoke` function along with a simple (but complete) example that can be run using `fvm_integration_tests`

```Rust
fn invoke(input: u32) -> u32 {
    let method_num = sdk::message::method_number();
    match_method!(method_num, {
        "Constructor" => {
            // this is a stateless actor so constructor does nothing
            NO_DATA_BLOCK_ID
        },
        "Greet" => {
            // TODO: load params, call greet(), save result and return block id
        },
        _ => {
            // abort due to unknown method
        }
    })
}
```

currently expands to this at build time (see the greeter example for the full body code)
```Rust
fn invoke(input: u32) -> u32 {
    let method_num = sdk::message::method_number();
    match method_num {
        1u64 => NO_DATA_BLOCK_ID,
        225812285u64 => {
            // TODO: load params, call greet(), save result and return block id
        }
        _ => {
            // abort due to unknown method
        }
    }
}
```