### PR TITLE
Parameter renaming

### DIFF
--- a/fil_fungible_token/src/receiver/types.rs
+++ b/fil_fungible_token/src/receiver/types.rs
@@ -25,7 +25,7 @@ pub struct TokenReceivedParams {
     /// The account that the tokens are being sent to (the receiver address)
     pub to: ActorID,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
     pub data: RawBytes,
 }
 

--- a/fil_fungible_token/src/receiver/types.rs
+++ b/fil_fungible_token/src/receiver/types.rs
@@ -18,8 +18,8 @@ pub trait FrcXXXTokenReceiver {
 
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct TokenReceivedParams {
-    /// Address of the sender or operator that initiated the transfer
-    pub sender: ActorID,
+    /// Address of the operator that initiated the transfer
+    pub operator: ActorID,
     /// The account that the tokens are being pulled from (the token actor address itself for mint)
     pub from: ActorID,
     /// The account that the tokens are being sent to (the receiver address)

--- a/fil_fungible_token/src/token/state.rs
+++ b/fil_fungible_token/src/token/state.rs
@@ -294,24 +294,24 @@ impl TokenState {
         bs: &BS,
         spender: u64,
         owner: u64,
-        value: &TokenAmount,
+        amount: &TokenAmount,
     ) -> Result<TokenAmount> {
         let current_allowance = self.get_allowance_between(bs, owner, spender)?;
 
-        if value.is_zero() {
+        if amount.is_zero() {
             return Ok(current_allowance);
         }
 
-        if current_allowance.lt(value) {
+        if current_allowance.lt(amount) {
             return Err(StateError::InsufficentAllowance {
                 owner,
                 spender,
                 allowance: current_allowance,
-                delta: value.clone(),
+                delta: amount.clone(),
             });
         }
 
-        let new_allowance = current_allowance - value;
+        let new_allowance = current_allowance - amount;
 
         // TODO: helper function to set a new allowance and flush hamts
         let owner_allowances = self.get_owner_allowance_map(bs, owner)?;

--- a/fil_fungible_token/src/token/state.rs
+++ b/fil_fungible_token/src/token/state.rs
@@ -29,11 +29,11 @@ pub enum StateError {
     #[error("negative balance caused by changing {owner:?}'s balance of {balance:?} by {delta:?}")]
     NegativeBalance { owner: ActorID, balance: TokenAmount, delta: TokenAmount },
     #[error(
-        "{spender:?} attempted to utilise {delta:?} of allowance {allowance:?} set by {owner:?}"
+        "{operator:?} attempted to utilise {delta:?} of allowance {allowance:?} set by {owner:?}"
     )]
     InsufficentAllowance {
         owner: ActorID,
-        spender: ActorID,
+        operator: ActorID,
         allowance: TokenAmount,
         delta: TokenAmount,
     },
@@ -54,7 +54,7 @@ pub struct TokenState {
 
     /// Map<ActorId, TokenAmount> of balances as a Hamt
     pub balances: Cid,
-    /// Map<ActorId, Map<ActorId, TokenAmount>> as a Hamt. Allowances are stored balances[owner][spender]
+    /// Map<ActorId, Map<ActorId, TokenAmount>> as a Hamt. Allowances are stored balances[owner][operator]
     pub allowances: Cid,
 }
 
@@ -180,19 +180,19 @@ impl TokenState {
         Ok(&self.supply)
     }
 
-    /// Get the allowance that an owner has approved for a spender
+    /// Get the allowance that an owner has approved for a operator
     ///
     /// If an existing allowance cannot be found, it is implicitly assumed to be zero
     pub fn get_allowance_between<BS: Blockstore>(
         &self,
         bs: &BS,
         owner: ActorID,
-        spender: ActorID,
+        operator: ActorID,
     ) -> Result<TokenAmount> {
         let owner_allowances = self.get_owner_allowance_map(bs, owner)?;
         match owner_allowances {
             Some(hamt) => {
-                let maybe_allowance = hamt.get(&spender)?;
+                let maybe_allowance = hamt.get(&operator)?;
                 if let Some(allowance) = maybe_allowance {
                     return Ok(allowance.clone().0);
                 }
@@ -202,17 +202,17 @@ impl TokenState {
         }
     }
 
-    /// Change the allowance between owner and spender by the specified delta
+    /// Change the allowance between owner and operator by the specified delta
     pub fn change_allowance_by<BS: Blockstore>(
         &mut self,
         bs: &BS,
         owner: ActorID,
-        spender: ActorID,
+        operator: ActorID,
         delta: &TokenAmount,
     ) -> Result<TokenAmount> {
         if delta.is_zero() {
             // This is a no-op as far as mutating state
-            return self.get_allowance_between(bs, owner, spender);
+            return self.get_allowance_between(bs, owner, operator);
         }
 
         let mut global_allowances_map = self.get_allowances_map(bs)?;
@@ -232,7 +232,7 @@ impl TokenState {
         };
 
         // calculate new allowance (max with zero)
-        let new_allowance = match allowance_map.get(&spender)? {
+        let new_allowance = match allowance_map.get(&operator)? {
             Some(existing_allowance) => existing_allowance.0.clone() + delta,
             None => (*delta).clone(),
         }
@@ -240,9 +240,9 @@ impl TokenState {
 
         // if the new allowance is zero, we can remove the entry from the state tree
         if new_allowance.is_zero() {
-            allowance_map.delete(&spender)?;
+            allowance_map.delete(&operator)?;
         } else {
-            allowance_map.set(spender, BigIntDe(new_allowance.clone()))?;
+            allowance_map.set(operator, BigIntDe(new_allowance.clone()))?;
         }
 
         // if the owner-allowance map is empty, remove it from the global allowances map
@@ -259,18 +259,18 @@ impl TokenState {
         Ok(new_allowance)
     }
 
-    /// Revokes an approved allowance by removing the entry from the owner-spender map
+    /// Revokes an approved allowance by removing the entry from the owner-operator map
     ///
     /// If that map becomes empty, it is removed from the root map.
     pub fn revoke_allowance<BS: Blockstore>(
         &mut self,
         bs: &BS,
         owner: ActorID,
-        spender: ActorID,
+        operator: ActorID,
     ) -> Result<()> {
         let allowance_map = self.get_owner_allowance_map(bs, owner)?;
         if let Some(mut map) = allowance_map {
-            map.delete(&spender)?;
+            map.delete(&operator)?;
             if map.is_empty() {
                 let mut root_allowance_map = self.get_allowances_map(bs)?;
                 root_allowance_map.delete(&owner)?;
@@ -292,11 +292,11 @@ impl TokenState {
     pub fn attempt_use_allowance<BS: Blockstore>(
         &mut self,
         bs: &BS,
-        spender: u64,
+        operator: u64,
         owner: u64,
         amount: &TokenAmount,
     ) -> Result<TokenAmount> {
-        let current_allowance = self.get_allowance_between(bs, owner, spender)?;
+        let current_allowance = self.get_allowance_between(bs, owner, operator)?;
 
         if amount.is_zero() {
             return Ok(current_allowance);
@@ -305,7 +305,7 @@ impl TokenState {
         if current_allowance.lt(amount) {
             return Err(StateError::InsufficentAllowance {
                 owner,
-                spender,
+                operator,
                 allowance: current_allowance,
                 delta: amount.clone(),
             });
@@ -317,7 +317,7 @@ impl TokenState {
         let owner_allowances = self.get_owner_allowance_map(bs, owner)?;
         // to reach here, allowance must have been previously non zero; so safe to assume the map exists
         let mut owner_allowances = owner_allowances.unwrap();
-        owner_allowances.set(spender, BigIntDe(new_allowance.clone()))?;
+        owner_allowances.set(operator, BigIntDe(new_allowance.clone()))?;
         let mut allowance_map = self.get_allowances_map(bs)?;
         allowance_map.set(owner, owner_allowances.flush()?)?;
         self.allowances = allowance_map.flush()?;
@@ -411,36 +411,36 @@ mod test {
         let bs = &MemoryBlockstore::new();
         let mut state = TokenState::new(&bs).unwrap();
         let owner: ActorID = 1;
-        let spender: ActorID = 2;
+        let operator: ActorID = 2;
 
         // initial allowance is zero
-        let initial_allowance = state.get_allowance_between(bs, owner, spender).unwrap();
+        let initial_allowance = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(initial_allowance, BigInt::zero());
 
         // can set a positive allowance
         let delta = BigInt::from(100);
-        let ret = state.change_allowance_by(bs, owner, spender, &delta).unwrap();
+        let ret = state.change_allowance_by(bs, owner, operator, &delta).unwrap();
         assert_eq!(ret, delta);
-        let allowance_1 = state.get_allowance_between(bs, owner, spender).unwrap();
+        let allowance_1 = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(allowance_1, delta);
 
         // vice-versa allowance was unaffected
-        let reverse_allowance = state.get_allowance_between(bs, spender, owner).unwrap();
+        let reverse_allowance = state.get_allowance_between(bs, operator, owner).unwrap();
         assert_eq!(reverse_allowance, BigInt::zero());
 
         // can subtract an allowance
         let delta = BigInt::from(-50);
-        let ret = state.change_allowance_by(bs, owner, spender, &delta).unwrap();
+        let ret = state.change_allowance_by(bs, owner, operator, &delta).unwrap();
         assert_eq!(ret, BigInt::from(50));
-        let allowance_2 = state.get_allowance_between(bs, owner, spender).unwrap();
+        let allowance_2 = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(allowance_2, allowance_1 + delta);
         assert_eq!(allowance_2, BigInt::from(50));
 
         // allowance won't go negative
         let delta = BigInt::from(-100);
-        let ret = state.change_allowance_by(bs, owner, spender, &delta).unwrap();
+        let ret = state.change_allowance_by(bs, owner, operator, &delta).unwrap();
         assert_eq!(ret, BigInt::zero());
-        let allowance_3 = state.get_allowance_between(bs, owner, spender).unwrap();
+        let allowance_3 = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(allowance_3, BigInt::zero());
     }
 
@@ -449,23 +449,23 @@ mod test {
         let bs = &MemoryBlockstore::new();
         let mut state = TokenState::new(bs).unwrap();
         let owner: ActorID = 1;
-        let spender: ActorID = 2;
+        let operator: ActorID = 2;
 
         // set a positive allowance
         let delta = BigInt::from(100);
-        state.change_allowance_by(bs, owner, spender, &delta).unwrap();
+        state.change_allowance_by(bs, owner, operator, &delta).unwrap();
 
         // can consume an allowance
         let new_allowance =
-            state.attempt_use_allowance(bs, spender, owner, &BigInt::from(60)).unwrap();
+            state.attempt_use_allowance(bs, operator, owner, &BigInt::from(60)).unwrap();
         assert_eq!(new_allowance, BigInt::from(40));
-        let new_allowance = state.get_allowance_between(bs, owner, spender).unwrap();
+        let new_allowance = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(new_allowance, BigInt::from(40));
 
         // cannot consume more allowance than approved
-        state.attempt_use_allowance(bs, spender, owner, &BigInt::from(50)).unwrap_err();
+        state.attempt_use_allowance(bs, operator, owner, &BigInt::from(50)).unwrap_err();
         // allowance was unchanged
-        let new_allowance = state.get_allowance_between(bs, owner, spender).unwrap();
+        let new_allowance = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(new_allowance, BigInt::from(40));
     }
 
@@ -474,17 +474,17 @@ mod test {
         let bs = &MemoryBlockstore::new();
         let mut state = TokenState::new(bs).unwrap();
         let owner: ActorID = 1;
-        let spender: ActorID = 2;
+        let operator: ActorID = 2;
 
         // set a positive allowance
         let delta = BigInt::from(100);
-        state.change_allowance_by(bs, owner, spender, &delta).unwrap();
-        state.change_allowance_by(bs, owner, spender, &delta).unwrap();
-        let allowance = state.get_allowance_between(bs, owner, spender).unwrap();
+        state.change_allowance_by(bs, owner, operator, &delta).unwrap();
+        state.change_allowance_by(bs, owner, operator, &delta).unwrap();
+        let allowance = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(allowance, BigInt::from(200));
 
-        state.revoke_allowance(bs, owner, spender).unwrap();
-        let allowance = state.get_allowance_between(bs, owner, spender).unwrap();
+        state.revoke_allowance(bs, owner, operator).unwrap();
+        let allowance = state.get_allowance_between(bs, owner, operator).unwrap();
         assert_eq!(allowance, BigInt::zero());
     }
 }

--- a/fil_fungible_token/src/token/types.rs
+++ b/fil_fungible_token/src/token/types.rs
@@ -98,7 +98,7 @@ pub trait FrcXXXToken {
 pub struct MintParams {
     pub initial_holder: ActorID,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -119,7 +119,7 @@ pub struct ChangeAllowanceParams {
     pub owner: Address,
     pub spender: Address,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
 }
 
 /// Params to get allowance between to addresses
@@ -142,7 +142,7 @@ pub struct AllowanceReturn {
     pub owner: Address,
     pub spender: Address,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
 }
 
 impl Cbor for ChangeAllowanceParams {}
@@ -155,7 +155,7 @@ impl Cbor for AllowanceReturn {}
 pub struct BurnParams {
     pub owner: Address,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
     pub data: RawBytes,
 }
 
@@ -176,7 +176,7 @@ pub struct TransferParams {
     pub from: Address,
     pub to: Address,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -184,7 +184,7 @@ pub struct TransferReturn {
     pub from: Address,
     pub to: Address,
     #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
+    pub amount: TokenAmount,
 }
 
 impl Cbor for TransferParams {}

--- a/fil_fungible_token/src/token/types.rs
+++ b/fil_fungible_token/src/token/types.rs
@@ -47,56 +47,45 @@ pub trait FrcXXXToken {
     /// This will method attempt to resolve addresses to ID-addresses
     fn balance_of(&self, params: Address) -> Result<TokenAmount>;
 
-    /// Atomically increase the amount that a spender can pull from the owner account
+    /// Atomically increase the amount that a operator can pull from the owner account
     ///
     /// The increase must be non-negative. Returns the new allowance between those two addresses if
     /// successful
     fn increase_allowance(&self, params: ChangeAllowanceParams) -> Result<AllowanceReturn>;
 
-    /// Atomically decrease the amount that a spender can pull from an account
+    /// Atomically decrease the amount that a operator can pull from an account
     ///
     /// The decrease must be non-negative. The resulting allowance is set to zero if the decrease is
     /// more than the current allowance. Returns the new allowance between the two addresses if
     /// successful
     fn decrease_allowance(&self, params: ChangeAllowanceParams) -> Result<AllowanceReturn>;
 
-    /// Set the allowance a spender has on the owner's account to zero
+    /// Set the allowance a operator has on the owner's account to zero
     fn revoke_allowance(&self, params: RevokeAllowanceParams) -> Result<AllowanceReturn>;
 
     /// Get the allowance between two addresses
     ///
-    /// The spender can burn or transfer the allowance amount out of the owner's address. If the
+    /// The operator can burn or transfer the allowance amount out of the owner's address. If the
     /// address of the owner cannot be resolved, this method returns an error. If the owner can be
-    /// resolved, but the spender address is not registered with an allowance, an implicit allowance
+    /// resolved, but the operator address is not registered with an allowance, an implicit allowance
     /// of 0 is returned
     fn allowance(&self, params: GetAllowanceParams) -> Result<AllowanceReturn>;
 
     /// Burn tokens from the caller's account, decreasing the total supply
     ///
     /// When burning tokens:
-    /// - Any holder MUST be allowed to burn their own tokens
-    /// - The balance of the holder MUST decrease by the amount burned
-    /// - This method MUST revert if the burn amount is more than the holder's balance
+    /// - Any owner MUST be allowed to burn their own tokens
+    /// - The balance of the owner MUST decrease by the amount burned
+    /// - This method MUST revert if the burn amount is more than the owner's balance
     fn burn(&self, params: BurnParams) -> Result<BurnReturn>;
 
-    /// Burn tokens from the owner's account, decreasing the total supply
-    ///
-    /// When burning on behalf of the owner:
-    /// - The same rules on the holder apply as `burn`
-    /// - This method MUST revert if the burn amount is more than the allowance authorised by the
-    /// owner
-    fn burn_from(&self, params: BurnParams) -> Result<BurnReturn>;
-
-    /// Transfer tokens from the caller to the receiver
-    ///
+    /// Transfer tokens from one account to another
     fn transfer(&self, params: TransferParams) -> Result<TransferReturn>;
-
-    fn transfer_from(&self, params: TransferParams) -> Result<TransferReturn>;
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct MintParams {
-    pub initial_holder: ActorID,
+    pub initial_owner: ActorID,
     #[serde(with = "bigint_ser")]
     pub amount: TokenAmount,
 }
@@ -117,7 +106,7 @@ impl Cbor for MintReturn {}
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ChangeAllowanceParams {
     pub owner: Address,
-    pub spender: Address,
+    pub operator: Address,
     #[serde(with = "bigint_ser")]
     pub amount: TokenAmount,
 }
@@ -126,21 +115,21 @@ pub struct ChangeAllowanceParams {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct GetAllowanceParams {
     pub owner: Address,
-    pub spender: Address,
+    pub operator: Address,
 }
 
 /// Instruction to revoke (set to 0) an allowance
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct RevokeAllowanceParams {
     pub owner: Address,
-    pub spender: Address,
+    pub operator: Address,
 }
 
 /// The updated value after allowance is increased or decreased
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct AllowanceReturn {
     pub owner: Address,
-    pub spender: Address,
+    pub operator: Address,
     #[serde(with = "bigint_ser")]
     pub amount: TokenAmount,
 }


### PR DESCRIPTION
- rename value -> amount when referring to tokens https://github.com/helix-onchain/filecoin/pull/46#discussion_r936131896
- replace &[u8] with RawBytes https://github.com/helix-onchain/filecoin/pull/46#discussion_r936132262

Third commit (maybe too drastic) unifies terminology for sender, spender, minter -> operator. The term operator captures the actor or entity that initiates a state change (or has the power to in the case of allowances)