### PR TITLE
Handle uninitialized accounts

### DIFF
--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -20,7 +20,9 @@ pub type Result<T> = std::result::Result<T, MessagingError>;
 pub enum MessagingError {
     #[error("fvm syscall error: `{0}`")]
     Syscall(#[from] ErrorNumber),
-    #[error("address not initialized: `{0}`")]
+    #[error("address could not be resolved: `{0}`")]
+    AddressNotResolved(Address),
+    #[error("address could not be initialized: `{0}`")]
     AddressNotInitialized(Address),
     #[error("ipld serialization error: `{0}`")]
     Ipld(#[from] IpldError),
@@ -77,7 +79,7 @@ impl Messaging for FvmMessenger {
     }
 
     fn resolve_id(&self, address: &Address) -> Result<ActorID> {
-        actor::resolve_address(address).ok_or(MessagingError::AddressNotInitialized(*address))
+        actor::resolve_address(address).ok_or(MessagingError::AddressNotResolved(*address))
     }
 
     fn initialize_account(&self, address: &Address) -> Result<ActorID> {
@@ -195,7 +197,7 @@ impl FakeAddressResolver {
         // else resolve it if it is an id address
         match address.payload() {
             fvm_shared::address::Payload::ID(id) => Ok(*id),
-            _ => Err(MessagingError::AddressNotInitialized(*address)),
+            _ => Err(MessagingError::AddressNotResolved(*address)),
         }
     }
 

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -40,9 +40,9 @@ pub trait Messaging {
         value: &TokenAmount,
     ) -> Result<Receipt>;
 
-    /// Resolves the given address to its ID address form
+    /// Attempts to resolve the given address to its ID address form
     ///
-    /// Returns MessagingError::AddressNotInitialised if the address could not be resolved
+    /// Returns MessagingError::AddressNotResolved if the address could not be resolved
     fn resolve_id(&self, address: &Address) -> Result<ActorID>;
 
     /// Creates an account at a pubkey address and returns the ID address

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -118,9 +118,7 @@ where
     fn resolve_to_id(&self, address: &Address) -> MessagingResult<ActorID> {
         let id = match self.msg.resolve_id(address) {
             Ok(addr) => addr,
-            Err(MessagingError::AddressNotInitialized(_e)) => {
-                self.msg.initialize_account(address)?
-            }
+            Err(MessagingError::AddressNotResolved(_e)) => self.msg.initialize_account(address)?,
             Err(e) => return Err(e),
         };
         Ok(id)
@@ -228,7 +226,7 @@ where
 
         match owner {
             Ok(owner) => Ok(self.state.get_balance(&self.bs, owner)?),
-            Err(MessagingError::AddressNotInitialized(_)) => {
+            Err(MessagingError::AddressNotResolved(_)) => {
                 // uninitialized address has implicit zero balance
                 Ok(TokenAmount::zero())
             }
@@ -244,7 +242,7 @@ where
         let owner = self.get_id(owner);
         let owner = match owner {
             Ok(owner) => owner,
-            Err(MessagingError::AddressNotInitialized(_)) => {
+            Err(MessagingError::AddressNotResolved(_)) => {
                 // uninitialized address has implicit zero allowance
                 return Ok(TokenAmount::zero());
             }
@@ -254,7 +252,7 @@ where
         let operator = self.get_id(operator);
         let operator = match operator {
             Ok(operator) => operator,
-            Err(MessagingError::AddressNotInitialized(_)) => {
+            Err(MessagingError::AddressNotResolved(_)) => {
                 // uninitialized address has implicit zero allowance
                 return Ok(TokenAmount::zero());
             }

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -528,8 +528,9 @@ mod test {
             .0
     }
 
-    fn assert_last_msg_eq(messenger: &FakeMessenger, expected: TokenReceivedParams) {
-        let last_called = messenger.last_hook.borrow().clone().unwrap();
+    fn assert_last_hook_call_eq(messenger: &FakeMessenger, expected: TokenReceivedParams) {
+        let last_called = messenger.last_message.borrow().clone().unwrap();
+        let last_called: TokenReceivedParams = last_called.deserialize().unwrap();
         assert_eq!(last_called, expected);
     }
 
@@ -608,7 +609,7 @@ mod test {
         token.mint(TOKEN_ACTOR, ALICE, &TokenAmount::zero(), &Default::default()).unwrap();
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: TOKEN_ACTOR.id().unwrap(),
@@ -632,7 +633,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(2_000_000));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: TOKEN_ACTOR.id().unwrap(),
@@ -650,7 +651,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(3_000_000));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: TOKEN_ACTOR.id().unwrap(),
@@ -674,7 +675,7 @@ mod test {
             .unwrap();
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: TOKEN_ACTOR.id().unwrap(),
@@ -700,7 +701,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(5_000_000));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: TOKEN_ACTOR.id().unwrap(),
@@ -824,15 +825,15 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // check receiver hook was called with correct shape
-        assert_eq!(
-            token.msg.last_hook.borrow().clone().unwrap(),
+        assert_last_hook_call_eq(
+            &token.msg,
             TokenReceivedParams {
                 operator: ALICE.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 amount: TokenAmount::from(60),
                 to: BOB.id().unwrap(),
                 data: Default::default(),
-            }
+            },
         );
 
         // cannot transfer a negative value
@@ -852,7 +853,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: ALICE.id().unwrap(),
@@ -872,7 +873,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: ALICE.id().unwrap(),
@@ -892,7 +893,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: ALICE.id().unwrap(),
@@ -917,7 +918,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: ALICE.id().unwrap(),
@@ -944,7 +945,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: ALICE.id().unwrap(),
@@ -1099,7 +1100,7 @@ mod test {
         assert_eq!(token.balance_of(CAROL).unwrap(), TokenAmount::zero());
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: CAROL.id().unwrap(),
@@ -1123,7 +1124,7 @@ mod test {
         assert_eq!(token.balance_of(CAROL).unwrap(), TokenAmount::from(40));
 
         // check receiver hook was called with correct shape
-        assert_last_msg_eq(
+        assert_last_hook_call_eq(
             &token.msg,
             TokenReceivedParams {
                 operator: CAROL.id().unwrap(),

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -988,7 +988,34 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::zero());
 
         // secp_address was initialized
-        assert!(token.get_id(secp_address).is_ok())
+        assert!(token.get_id(secp_address).is_ok());
+
+        let actor_address = &actor_address();
+        // transfers from actors fail with uninitializable
+        let err = token
+            .transfer(
+                actor_address,
+                actor_address,
+                ALICE,
+                &TokenAmount::zero(),
+                &Default::default(),
+            )
+            .unwrap_err();
+
+        if let TokenError::Messaging(MessagingError::AddressNotInitialized(e)) = err {
+            assert_eq!(e, *actor_address);
+        } else {
+            panic!("Expected AddressNotInitialized error");
+        }
+
+        // balances unchanged
+        assert_eq!(token.balance_of(secp_address).unwrap(), TokenAmount::zero());
+        assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::zero());
+        // supply unchanged
+        assert_eq!(token.total_supply(), TokenAmount::zero());
+
+        // actor address was not initialized
+        assert!(token.get_id(actor_address).is_err())
     }
 
     #[test]

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -515,8 +515,21 @@ where
             let to_id = self.resolve_or_init(to)?;
             // skip allowance check for self-managed transfers
             self.transaction(|state, bs| {
-                state.change_balance_by(&bs, to_id, amount)?;
-                state.change_balance_by(&bs, from, &amount.neg())?;
+                // don't change balance if to == from, but must check that the transfer doesn't exceed balance
+                if to_id == from {
+                    let balance = state.get_balance(&bs, from)?;
+                    if balance.lt(amount) {
+                        return Err(TokenStateError::InsufficientBalance {
+                            owner: from,
+                            balance,
+                            delta: amount.clone().neg(),
+                        }
+                        .into());
+                    }
+                } else {
+                    state.change_balance_by(&bs, to_id, amount)?;
+                    state.change_balance_by(&bs, from, &amount.neg())?;
+                }
                 Ok(())
             })?;
 
@@ -571,8 +584,21 @@ where
         // update token state
         self.transaction(|state, bs| {
             state.attempt_use_allowance(&bs, operator_id, from, amount)?;
-            state.change_balance_by(&bs, to_id, amount)?;
-            state.change_balance_by(&bs, from, &amount.neg())?;
+            // don't change balance if to == from, but must check that the transfer doesn't exceed balance
+            if to_id == from {
+                let balance = state.get_balance(&bs, from)?;
+                if balance.lt(amount) {
+                    return Err(TokenStateError::InsufficientBalance {
+                        owner: from,
+                        balance,
+                        delta: amount.clone().neg(),
+                    }
+                    .into());
+                }
+            } else {
+                state.change_balance_by(&bs, to_id, amount)?;
+                state.change_balance_by(&bs, from, &amount.neg())?;
+            }
             Ok(())
         })?;
 
@@ -598,6 +624,7 @@ mod test {
     use fvm_shared::address::{Address, BLS_PUB_LEN};
     use fvm_shared::econ::TokenAmount;
     use num_traits::Zero;
+    use std::ops::Neg;
 
     use super::state::StateError;
     use super::Token;
@@ -1236,6 +1263,10 @@ mod test {
 
         // mint 100 for the owner
         token.mint(ALICE, ALICE, &TokenAmount::from(100), &Default::default()).unwrap();
+
+        // operator can't transfer without allowance, even if amount is zero
+        token.transfer(CAROL, ALICE, ALICE, &TokenAmount::zero(), &Default::default()).unwrap_err();
+
         // approve 100 spending allowance for operator
         token.increase_allowance(ALICE, CAROL, &TokenAmount::from(100)).unwrap();
         // operator makes transfer of 60 from owner -> receiver
@@ -1296,7 +1327,7 @@ mod test {
         let initialised_address = &secp_address();
         token.msg.initialize_account(initialised_address).unwrap();
 
-        // an initialised pubkey can transfer zero out of Alice balance
+        // an initialised pubkey cannot transfer zero out of Alice balance without an allowance
         token
             .transfer(
                 initialised_address,
@@ -1306,6 +1337,7 @@ mod test {
                 &Default::default(),
             )
             .unwrap_err();
+
         // balances remained same
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::from(100));
         assert_eq!(token.balance_of(initialised_address).unwrap(), TokenAmount::zero());
@@ -1516,8 +1548,9 @@ mod test {
         assert_eq!(token.balance_of(TREASURY).unwrap(), TokenAmount::from(400_000));
         assert_eq!(token.allowance(TREASURY, secp_address).unwrap(), TokenAmount::zero());
 
-        // but can burn zero
+        // cannot burn zero now that allowance is zero
         let res = token.burn(secp_address, TREASURY, &TokenAmount::zero());
+
         // balances unchanged
         assert!(res.is_err());
         assert_eq!(token.total_supply(), TokenAmount::from(400_000));
@@ -1679,6 +1712,158 @@ mod test {
         } else {
             panic!("expected AddressNotResolved error");
         }
+    }
+
+    #[test]
+    fn test_account_combinations() {
+        fn setup_accounts(
+            operator: &Address,
+            from: &Address,
+            allowance: &TokenAmount,
+            balance: &TokenAmount,
+        ) -> Token<MemoryBlockstore, FakeMessenger> {
+            // fresh token state
+            let mut token = new_token();
+            // set allowance if not zero (avoiding unecessary account instantiation)
+            if !allowance.is_zero() && !(from == operator) {
+                token.increase_allowance(from, operator, allowance).unwrap();
+            }
+            // set balance if not zero (avoiding unecessary account insantiation)
+            if !balance.is_zero() {
+                token.mint(from, from, balance, &Default::default()).unwrap();
+            }
+            token
+        }
+
+        fn assert_behaviour(
+            operator: &Address,
+            from: &Address,
+            allowance: u32,
+            balance: u32,
+            transfer: u32,
+            behaviour: &str,
+        ) {
+            let mut token = setup_accounts(
+                operator,
+                from,
+                &TokenAmount::from(allowance),
+                &TokenAmount::from(balance),
+            );
+            let res = token.transfer(
+                operator,
+                from,
+                operator,
+                &TokenAmount::from(transfer),
+                &Default::default(),
+            );
+
+            match behaviour {
+                "OK" => res.expect("expected transfer to succeed"),
+                "ALLOWANCE_ERR" => {
+                    let err = res.unwrap_err();
+                    if let TokenError::TokenState(StateError::InsufficientAllowance {
+                        // can't match addresses as may be pubkey or ID (though they would resolve to the same)
+                        owner: _,
+                        operator: _,
+                        allowance: a,
+                        delta,
+                    }) = err
+                    {
+                        assert_eq!(a, TokenAmount::from(allowance));
+                        assert_eq!(delta, TokenAmount::from(transfer));
+                    } else {
+                        panic!("unexpected error {:?}", err);
+                    }
+                }
+                "BALANCE_ERR" => {
+                    let err = res.unwrap_err();
+                    if let TokenError::TokenState(StateError::InsufficientBalance {
+                        owner,
+                        balance: b,
+                        delta,
+                    }) = err
+                    {
+                        assert_eq!(owner, token.msg.resolve_id(from).unwrap());
+                        assert_eq!(delta, TokenAmount::from(transfer).neg());
+                        assert_eq!(b, TokenAmount::from(balance));
+                    } else {
+                        panic!("unexpected error {:?}", err);
+                    }
+                }
+                "ADDRESS_ERR" => {
+                    let err = res.unwrap_err();
+                    if let TokenError::Messaging(MessagingError::AddressNotInitialized(addr)) = err
+                    {
+                        assert!((addr == *operator) || (addr == *from));
+                    } else {
+                        panic!("unexpected error {:?}", err);
+                    }
+                }
+                _ => panic!("test case not implemented"),
+            }
+        }
+
+        // distinct resolvable address operates on resolvable address
+        assert_behaviour(ALICE, BOB, 0, 0, 0, "ALLOWANCE_ERR");
+        assert_behaviour(ALICE, BOB, 0, 0, 1, "ALLOWANCE_ERR");
+        assert_behaviour(ALICE, BOB, 0, 1, 0, "ALLOWANCE_ERR");
+        assert_behaviour(ALICE, BOB, 0, 1, 1, "ALLOWANCE_ERR");
+        assert_behaviour(ALICE, BOB, 1, 0, 0, "OK");
+        assert_behaviour(ALICE, BOB, 1, 0, 1, "BALANCE_ERR");
+        assert_behaviour(ALICE, BOB, 1, 1, 0, "OK");
+        assert_behaviour(ALICE, BOB, 1, 1, 1, "OK");
+
+        // initialisable (but uninitialised) address operates on resolved address
+        assert_behaviour(&secp_address(), BOB, 0, 0, 0, "ALLOWANCE_ERR");
+        assert_behaviour(&secp_address(), BOB, 0, 0, 1, "ALLOWANCE_ERR");
+        assert_behaviour(&secp_address(), BOB, 0, 1, 0, "ALLOWANCE_ERR");
+        assert_behaviour(&secp_address(), BOB, 0, 1, 1, "ALLOWANCE_ERR");
+        // impossible to have non-zero allowance specified for uninitialised address
+
+        // resolvable address operates on initialisable address
+        assert_behaviour(BOB, &secp_address(), 0, 0, 0, "ALLOWANCE_ERR");
+        assert_behaviour(BOB, &secp_address(), 0, 0, 1, "ALLOWANCE_ERR");
+        // impossible to have uninitialised address have a balance
+        // impossible to have non-zero allowance specified by an uninitialised address
+
+        // distinct uninitialised address operates on uninitialised address
+        assert_behaviour(&bls_address(), &secp_address(), 0, 0, 0, "ALLOWANCE_ERR");
+        assert_behaviour(&bls_address(), &secp_address(), 0, 0, 1, "ALLOWANCE_ERR");
+        // impossible to have uninitialised address have a balance
+        // impossible to have non-zero allowance specified by an uninitialised address
+
+        // distinct actor address operates on actor address
+        assert_behaviour(&Address::new_actor(&[1]), &actor_address(), 0, 0, 0, "ALLOWANCE_ERR");
+        assert_behaviour(&Address::new_actor(&[1]), &actor_address(), 0, 0, 1, "ALLOWANCE_ERR");
+        // impossible for actor to have balance (for now)
+        // impossible for actor to have allowance (for now)
+
+        // actor addresses are currently never initialisable, but may be in the future, so it returns allowance errors to mirror pubkey behaviour
+        // id address operates on actor address
+        assert_behaviour(ALICE, &actor_address(), 0, 0, 0, "ALLOWANCE_ERR");
+        assert_behaviour(ALICE, &actor_address(), 0, 0, 1, "ALLOWANCE_ERR");
+        // impossible for actor to have balance (for now)
+        // impossible for actor to have allowance (for now)
+        // currently the same actor will fail to transfer to itself, here it fails with an address error as for self transfers, we
+        // attempt to resolve the "from" address but currently that's not possible
+        assert_behaviour(&actor_address(), &actor_address(), 0, 0, 0, "ADDRESS_ERR");
+        assert_behaviour(&actor_address(), &actor_address(), 0, 0, 1, "ADDRESS_ERR");
+
+        // transfers should never fail with allowance err when the operator is the owner
+        // all allowance err should be replaced with successes or balance errs
+        assert_behaviour(ALICE, ALICE, 0, 0, 0, "OK");
+        assert_behaviour(ALICE, ALICE, 0, 0, 1, "BALANCE_ERR");
+        assert_behaviour(ALICE, ALICE, 0, 1, 0, "OK");
+        assert_behaviour(ALICE, ALICE, 0, 1, 1, "OK");
+        assert_behaviour(ALICE, ALICE, 1, 0, 0, "OK");
+        assert_behaviour(ALICE, ALICE, 1, 0, 1, "BALANCE_ERR");
+        assert_behaviour(ALICE, ALICE, 1, 1, 0, "OK");
+        assert_behaviour(ALICE, ALICE, 1, 1, 1, "OK");
+        // pubkey to pubkey
+        assert_behaviour(&secp_address(), &secp_address(), 0, 0, 0, "OK");
+        assert_behaviour(&secp_address(), &secp_address(), 0, 0, 1, "BALANCE_ERR");
+        assert_behaviour(&bls_address(), &bls_address(), 0, 0, 0, "OK");
+        assert_behaviour(&bls_address(), &bls_address(), 0, 0, 1, "BALANCE_ERR");
     }
 
     // TODO: test for re-entrancy bugs by implementing a MethodCaller that calls back on the token contract

--- a/fil_fungible_token/src/token/state.rs
+++ b/fil_fungible_token/src/token/state.rs
@@ -299,6 +299,15 @@ impl TokenState {
     ) -> Result<TokenAmount> {
         let current_allowance = self.get_allowance_between(bs, owner, operator)?;
 
+        if current_allowance.is_zero() && operator != owner {
+            return Err(StateError::InsufficientAllowance {
+                owner: Address::new_id(owner),
+                operator: Address::new_id(operator),
+                allowance: current_allowance,
+                delta: amount.clone(),
+            });
+        }
+
         if amount.is_zero() {
             return Ok(current_allowance);
         }

--- a/fil_fungible_token/src/token/state.rs
+++ b/fil_fungible_token/src/token/state.rs
@@ -8,6 +8,7 @@ use fvm_ipld_encoding::CborStore;
 use fvm_ipld_encoding::DAG_CBOR;
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_ipld_hamt::Hamt;
+use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::Zero;
@@ -32,8 +33,8 @@ pub enum StateError {
         "{operator:?} attempted to utilise {delta:?} of allowance {allowance:?} set by {owner:?}"
     )]
     InsufficentAllowance {
-        owner: ActorID,
-        operator: ActorID,
+        owner: Address,
+        operator: Address,
         allowance: TokenAmount,
         delta: TokenAmount,
     },
@@ -304,8 +305,8 @@ impl TokenState {
 
         if current_allowance.lt(amount) {
             return Err(StateError::InsufficentAllowance {
-                owner,
-                operator,
+                owner: Address::new_id(owner),
+                operator: Address::new_id(operator),
                 allowance: current_allowance,
                 delta: amount.clone(),
             });

--- a/fil_fungible_token/src/token/state.rs
+++ b/fil_fungible_token/src/token/state.rs
@@ -32,7 +32,7 @@ pub enum StateError {
     #[error(
         "{operator:?} attempted to utilise {delta:?} of allowance {allowance:?} set by {owner:?}"
     )]
-    InsufficentAllowance {
+    InsufficientAllowance {
         owner: Address,
         operator: Address,
         allowance: TokenAmount,
@@ -304,7 +304,7 @@ impl TokenState {
         }
 
         if current_allowance.lt(amount) {
-            return Err(StateError::InsufficentAllowance {
+            return Err(StateError::InsufficientAllowance {
                 owner: Address::new_id(owner),
                 operator: Address::new_id(operator),
                 allowance: current_allowance,


### PR DESCRIPTION
Addressing:
https://github.com/helix-onchain/filecoin/issues/31
https://github.com/helix-onchain/filecoin/issues/32

This implements the behaviour discussed on Slack except in the case of Actor addresses. Whereas we concluded that [Actor addresses should mirror uninitialized pubkey addresses](https://docs.google.com/spreadsheets/d/1c0A3oeB3fyO2Q3zQZubZZqUyC7AK9gGgOhgMLHtCuls/edit#gid=0) when transferring (non)-zero amounts from them, I propose that they actually forward the AddressNotInitialised error returned from the messaging layer. This inconsistency reflects a real underlying inconsistency in the behaviour of Actor-addresses. Eventually, if/when Actor-addresses are initializable, upgrading the injected messaging layer will automatically cause Actor-addresses to behave the same as other addresses without modifying the library code. 

Not having to account for Actor addresses simplifies the library code by simply initializing accounts wherever necessary and not needing a separate case to deal with zero amounts. Not treating zero amounts differently does mean however, that transfers, burns and mints of amount zero will initialise any uninitialised accounts.

A further extension to the current behaviour as a followup could potentially account for zero burns, transfers and mints as a special case and avoid unecessary account initialisations. This would not change any externally observed behaviour of the token library but can save gas/state-tree/VM-state bloat (https://github.com/helix-onchain/filecoin/pull/57#discussion_r938506584) However, on the balance, I don't think the extra complexity introduced to our Token code would be worth it.