### PR TITLE
map TokenError to ExitCodes

### DIFF
--- a/fil_fungible_token/Cargo.toml
+++ b/fil_fungible_token/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+fvm_dispatch = { version = "0.1.0", path = "../fvm_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -313,9 +313,8 @@ mod test_fake_messenger {
     }
     use fvm_shared::address::{Address, BLS_PUB_LEN};
 
-    use crate::runtime::messaging::Messaging;
-
     use super::FakeMessenger;
+    use crate::runtime::messaging::Messaging;
 
     /// Simple test checking that the fake messenger uses the address resolver to resolve addresses
     /// The resolution of addresses is tested in the test_address_resolver module

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+use fvm_dispatch::method_hash;
 use fvm_ipld_encoding::Error as IpldError;
 use fvm_ipld_encoding::RawBytes;
 use fvm_sdk::{actor, message, send, sys::ErrorNumber};
@@ -51,11 +52,9 @@ pub trait Messaging {
     fn initialize_account(&self, address: &Address) -> Result<ActorID>;
 }
 
-// TODO: use fvm_dispatch here (when it supports compile time method resolution)
-// TODO: ^^ necessitates determining conventional method names for receiver hooks
-// currently, the method number comes from taking the name as "TokensReceived" and applying
+// the method number comes from taking the name as "TokensReceived" and applying
 // the transformation described in https://github.com/filecoin-project/FIPs/pull/399
-pub const RECEIVER_HOOK_METHOD_NUM: u64 = 1361519036;
+pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("TokensReceived");
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FvmMessenger {}

--- a/fil_fungible_token/src/token/error.rs
+++ b/fil_fungible_token/src/token/error.rs
@@ -1,0 +1,96 @@
+use fvm_ipld_encoding::Error as SerializationError;
+use fvm_sdk::sys::ErrorNumber;
+use fvm_shared::address::{Address, Error as AddressError};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::ActorID;
+use thiserror::Error;
+
+use crate::runtime::messaging::MessagingError;
+use crate::token::state::StateError as TokenStateError;
+use crate::token::state::StateInvariantError;
+
+#[derive(Error, Debug)]
+pub enum TokenError {
+    #[error("error in underlying state {0}")]
+    TokenState(#[from] TokenStateError),
+    #[error("value {amount:?} for {name:?} must be non-negative")]
+    InvalidNegative { name: &'static str, amount: TokenAmount },
+    #[error("amount {amount:?} for {name:?} must be a multiple of {granularity:?}")]
+    InvalidGranularity { name: &'static str, amount: TokenAmount, granularity: u64 },
+    #[error("error calling receiver hook: {0}")]
+    Messaging(#[from] MessagingError),
+    #[error("receiver hook aborted when {operator:?} sent {amount:?} to {to:?} from {from:?} with exit code {exit_code:?}")]
+    ReceiverHook {
+        /// Whose balance is being debited
+        from: ActorID,
+        /// Whose balance is being credited
+        to: ActorID,
+        /// Who initiated the transfer of funds
+        operator: ActorID,
+        amount: TokenAmount,
+        exit_code: ExitCode,
+    },
+    #[error("expected {address:?} to be a resolvable id address but threw {source:?} when attempting to resolve")]
+    InvalidIdAddress {
+        address: Address,
+        #[source]
+        source: AddressError,
+    },
+    #[error("error during serialization {0}")]
+    Serialization(#[from] SerializationError),
+    #[error("error in state invariants {0}")]
+    StateInvariant(#[from] StateInvariantError),
+}
+
+impl From<TokenError> for ExitCode {
+    fn from(error: TokenError) -> Self {
+        match error {
+            TokenError::ReceiverHook { from: _, to: _, operator: _, amount: _, exit_code } => {
+                // simply pass through the exit code from the receiver but we could set a flag bit to
+                // distinguish it if needed (e.g. 0x0100 | exit_code)
+                exit_code
+            }
+            TokenError::InvalidIdAddress { address: _, source: _ } => ExitCode::USR_NOT_FOUND,
+            TokenError::Serialization(_) => ExitCode::USR_SERIALIZATION,
+            TokenError::InvalidGranularity { name: _, amount: _, granularity: _ }
+            | TokenError::InvalidNegative { name: _, amount: _ } => ExitCode::USR_ILLEGAL_ARGUMENT,
+            TokenError::StateInvariant(_) => ExitCode::USR_ILLEGAL_STATE,
+            TokenError::TokenState(state_error) => match state_error {
+                TokenStateError::IpldHamt(_) | TokenStateError::Serialization(_) => {
+                    ExitCode::USR_SERIALIZATION
+                }
+                TokenStateError::NegativeTotalSupply { supply: _, delta: _ }
+                | TokenStateError::MissingState(_) => ExitCode::USR_ILLEGAL_STATE,
+                TokenStateError::InsufficientBalance { balance: _, delta: _, owner: _ }
+                | TokenStateError::InsufficientAllowance {
+                    owner: _,
+                    operator: _,
+                    allowance: _,
+                    delta: _,
+                } => ExitCode::USR_INSUFFICIENT_FUNDS,
+            },
+            TokenError::Messaging(messaging_error) => match messaging_error {
+                MessagingError::Syscall(e) => match e {
+                    ErrorNumber::IllegalArgument => ExitCode::USR_ILLEGAL_ARGUMENT,
+                    ErrorNumber::Forbidden | ErrorNumber::IllegalOperation => {
+                        ExitCode::USR_FORBIDDEN
+                    }
+                    ErrorNumber::AssertionFailed => ExitCode::USR_ASSERTION_FAILED,
+                    ErrorNumber::InsufficientFunds => ExitCode::USR_INSUFFICIENT_FUNDS,
+                    ErrorNumber::IllegalCid
+                    | ErrorNumber::NotFound
+                    | ErrorNumber::InvalidHandle => ExitCode::USR_NOT_FOUND,
+                    ErrorNumber::Serialization | ErrorNumber::IllegalCodec => {
+                        ExitCode::USR_SERIALIZATION
+                    }
+                    ErrorNumber::LimitExceeded => ExitCode::USR_UNSPECIFIED,
+                    _ => unreachable!(),
+                },
+                MessagingError::AddressNotResolved(_)
+                | MessagingError::AddressNotInitialized(_) => ExitCode::USR_NOT_FOUND,
+                MessagingError::Ipld(_) => ExitCode::USR_SERIALIZATION,
+            },
+        }
+    }
+}

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -13,13 +13,12 @@ use num_traits::Signed;
 use num_traits::Zero;
 use thiserror::Error;
 
+use self::state::StateInvariantError;
+use self::state::{StateError as TokenStateError, TokenState};
 use crate::receiver::types::TokenReceivedParams;
 use crate::runtime::messaging::{Messaging, MessagingError};
 use crate::runtime::messaging::{Result as MessagingResult, RECEIVER_HOOK_METHOD_NUM};
 use crate::token::TokenError::InvalidGranularity;
-
-use self::state::StateInvariantError;
-use self::state::{StateError as TokenStateError, TokenState};
 
 pub mod state;
 pub mod types;
@@ -653,11 +652,12 @@ fn validate_amount<'a>(
 
 #[cfg(test)]
 mod test {
+    use std::ops::Neg;
+
     use fvm_ipld_blockstore::MemoryBlockstore;
     use fvm_shared::address::{Address, BLS_PUB_LEN};
     use fvm_shared::econ::TokenAmount;
     use num_traits::Zero;
-    use std::ops::Neg;
 
     use super::state::StateError;
     use super::Token;

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -4,6 +4,7 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::Error as SerializationError;
 use fvm_ipld_encoding::RawBytes;
+use fvm_sdk::sys::ErrorNumber;
 use fvm_shared::address::Address;
 use fvm_shared::address::Error as AddressError;
 use fvm_shared::econ::TokenAmount;
@@ -58,6 +59,53 @@ pub enum TokenError {
     Serialization(#[from] SerializationError),
     #[error("error in state invariants {0}")]
     StateInvariant(#[from] StateInvariantError),
+}
+
+impl From<TokenError> for ExitCode {
+    fn from(error: TokenError) -> Self {
+        match error {
+            TokenError::ReceiverHook { from: _, to: _, operator: _, amount: _, exit_code } => {
+                exit_code
+            }
+            TokenError::InvalidIdAddress { address: _, source: _ } => ExitCode::USR_NOT_FOUND,
+            TokenError::Serialization(_) => ExitCode::USR_SERIALIZATION,
+            TokenError::InvalidNegative(_) => ExitCode::USR_ILLEGAL_ARGUMENT,
+            TokenError::State(state_error) => match state_error {
+                StateError::IpldHamt(_) | StateError::Serialization(_) => {
+                    ExitCode::USR_SERIALIZATION
+                }
+                StateError::MissingState(_) => ExitCode::USR_ILLEGAL_STATE,
+                StateError::NegativeBalance { balance: _, delta: _, owner: _ }
+                | StateError::InsufficentAllowance {
+                    owner: _,
+                    operator: _,
+                    allowance: _,
+                    delta: _,
+                } => ExitCode::USR_FORBIDDEN,
+                StateError::NegativeTotalSupply { supply: _, delta: _ } => ExitCode::USR_FORBIDDEN,
+            },
+            TokenError::Messaging(messaging_error) => match messaging_error {
+                MessagingError::Syscall(e) => match e {
+                    ErrorNumber::IllegalArgument => ExitCode::USR_ILLEGAL_ARGUMENT,
+                    ErrorNumber::Forbidden | ErrorNumber::IllegalOperation => {
+                        ExitCode::USR_FORBIDDEN
+                    }
+                    ErrorNumber::AssertionFailed => ExitCode::USR_ASSERTION_FAILED,
+                    ErrorNumber::InsufficientFunds => ExitCode::USR_INSUFFICIENT_FUNDS,
+                    ErrorNumber::IllegalCid
+                    | ErrorNumber::NotFound
+                    | ErrorNumber::InvalidHandle => ExitCode::USR_NOT_FOUND,
+                    ErrorNumber::Serialization | ErrorNumber::IllegalCodec => {
+                        ExitCode::USR_SERIALIZATION
+                    }
+                    ErrorNumber::LimitExceeded => ExitCode::USR_UNSPECIFIED,
+                    _ => unreachable!(),
+                },
+                MessagingError::AddressNotInitialized(_) => ExitCode::USR_NOT_FOUND,
+                MessagingError::Ipld(_) => ExitCode::USR_SERIALIZATION,
+            },
+        }
+    }
 }
 
 type Result<T> = std::result::Result<T, TokenError>;

--- a/fvm_dispatch/hasher/src/hash.rs
+++ b/fvm_dispatch/hasher/src/hash.rs
@@ -1,7 +1,6 @@
-use thiserror::Error;
-
 #[cfg(not(feature = "no_sdk"))]
 use fvm_sdk::crypto;
+use thiserror::Error;
 
 /// Minimal interface for a hashing function
 ///

--- a/fvm_dispatch/macros/src/lib.rs
+++ b/fvm_dispatch/macros/src/lib.rs
@@ -1,6 +1,5 @@
-use proc_macro::TokenStream;
-
 use hasher::hash::MethodResolver;
+use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{parse_macro_input, LitStr, Result};

--- a/fvm_dispatch/src/message.rs
+++ b/fvm_dispatch/src/message.rs
@@ -1,13 +1,11 @@
-use thiserror::Error;
-
-use crate::hash::{Hasher, MethodNameErr, MethodResolver};
-
 use fvm_ipld_encoding::RawBytes;
+#[cfg(target_family = "wasm")]
+use fvm_sdk::send;
 use fvm_sdk::sys::ErrorNumber;
 use fvm_shared::{address::Address, econ::TokenAmount, receipt::Receipt};
+use thiserror::Error;
 
-#[cfg(target_family = "wasm")]
-use fvm_sdk::send; // fvm_sdk syscalls only work for WASM targets
+use crate::hash::{Hasher, MethodNameErr, MethodResolver}; // fvm_sdk syscalls only work for WASM targets
 
 /// Utility to invoke standard methods on deployed actors
 #[derive(Default)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 use_small_heuristics = "Max"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
https://github.com/helix-onchain/filecoin/issues/58

I don't know if I'm going down the right path. I'm not quite sure how well this fits in to what you need but this could be used:

```
token
    .mint(operator, to, &params.amount, RawBytes::default())
    .map_err(ExitCode::from)
```

Which results in a `Result<T, ExitCode>`