### PR TITLE
add invariant checks for TokenState

### DIFF
--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -1,7 +1,7 @@
 mod state;
 mod types;
 
-use self::state::{StateError, TokenState};
+use self::state::{StateError, StateInvariantError, TokenState};
 use crate::receiver::types::TokenReceivedParams;
 use crate::runtime::messaging::{Messaging, MessagingError};
 use crate::runtime::messaging::{Result as MessagingResult, RECEIVER_HOOK_METHOD_NUM};
@@ -47,6 +47,8 @@ pub enum TokenError {
     },
     #[error("error during serialization {0}")]
     Serialization(#[from] SerializationError),
+    #[error("error in state invariants {0}")]
+    StateInvariant(#[from] StateInvariantError),
 }
 
 type Result<T> = std::result::Result<T, TokenError>;
@@ -130,6 +132,12 @@ where
     /// if it wasn't found
     fn get_id(&self, address: &Address) -> MessagingResult<ActorID> {
         self.msg.resolve_id(address)
+    }
+
+    /// Checks the state invariants, throwing an error if they are not met
+    pub fn check_invariants(&self) -> Result<()> {
+        self.state.check_invariants(&self.bs)?;
+        Ok(())
     }
 }
 
@@ -723,6 +731,8 @@ mod test {
         assert_eq!(token.balance_of(&secp_address).unwrap(), TokenAmount::from(1_000_000));
         assert_eq!(token.balance_of(&bls_address).unwrap(), TokenAmount::from(1_000_000));
         assert_eq!(token.total_supply(), TokenAmount::from(5_000_000));
+
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -749,6 +759,7 @@ mod test {
         // state remained unchanged
         assert_eq!(token.balance_of(TREASURY).unwrap(), TokenAmount::zero());
         assert_eq!(token.total_supply(), TokenAmount::zero());
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -793,6 +804,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::zero());
         // alice's account unaffected
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::zero());
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -807,6 +819,7 @@ mod test {
         // balances and supply were unchanged
         assert_eq!(token.total_supply(), TokenAmount::from(1_000_000));
         assert_eq!(token.balance_of(TREASURY).unwrap(), TokenAmount::from(1_000_000));
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -956,6 +969,7 @@ mod test {
                 data: Default::default(),
             },
         );
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1006,6 +1020,7 @@ mod test {
         // balances unchanged
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::from(100));
         assert_eq!(token.balance_of(BOB).unwrap(), TokenAmount::from(0));
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1023,6 +1038,7 @@ mod test {
         // balances remained unchanged
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::from(50));
         assert_eq!(token.balance_of(BOB).unwrap(), TokenAmount::zero());
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1082,6 +1098,7 @@ mod test {
         token
             .increase_allowance(ALICE, uninitializable_address, &TokenAmount::from(10))
             .unwrap_err();
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1138,6 +1155,7 @@ mod test {
 
         // verify allowance is correct
         assert_eq!(token.allowance(ALICE, CAROL).unwrap(), TokenAmount::zero());
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1179,6 +1197,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from(400_000));
         assert_eq!(token.balance_of(TREASURY).unwrap(), TokenAmount::from(400_000));
         assert_eq!(token.allowance(TREASURY, ALICE).unwrap(), TokenAmount::zero());
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1200,6 +1219,7 @@ mod test {
 
         // verify allowance was not spent
         assert_eq!(token.allowance(ALICE, CAROL).unwrap(), TokenAmount::from(40));
+        token.check_invariants().unwrap();
     }
 
     #[test]
@@ -1223,6 +1243,7 @@ mod test {
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::from(50));
         assert_eq!(token.balance_of(BOB).unwrap(), TokenAmount::zero());
         assert_eq!(token.allowance(ALICE, BOB).unwrap(), TokenAmount::from(100));
+        token.check_invariants().unwrap();
     }
 
     // TODO: test for re-entrancy bugs by implementing a MethodCaller that calls back on the token contract


### PR DESCRIPTION
Adds some invariant checking thats suitable to be called during unit/integration testing
https://github.com/helix-onchain/filecoin/issues/63

