### PR TITLE
Receiver hook call guard for mint/transfer

### DIFF
--- a/fil_fungible_token/src/receiver/mod.rs
+++ b/fil_fungible_token/src/receiver/mod.rs
@@ -1,1 +1,56 @@
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
+use num_traits::Zero;
+use types::TokensReceivedParams;
+
+use crate::runtime::messaging::{Messaging, RECEIVER_HOOK_METHOD_NUM};
+use crate::token::TokenError;
+
 pub mod types;
+
+#[derive(Debug)]
+pub struct ReceiverHookGuard<T> {
+    address: Address,
+    params: Option<TokensReceivedParams>,
+    return_value: Option<T>,
+}
+
+impl<T> ReceiverHookGuard<T> {
+    pub fn new(address: Address, params: TokensReceivedParams, return_value: T) -> Self {
+        ReceiverHookGuard { address, params: Some(params), return_value: Some(return_value) }
+    }
+    pub fn call(&mut self, msg: &dyn Messaging) -> std::result::Result<T, TokenError> {
+        if self.params.is_none() {
+            return Err(TokenError::ReceiverHookGuardAlreadyCalled);
+        }
+
+        // this will leave self.params set to None, so a further attempt to call() will fail
+        let params = self.params.take().unwrap();
+
+        let receipt = msg.send(
+            &self.address,
+            RECEIVER_HOOK_METHOD_NUM,
+            &RawBytes::serialize(&params)?,
+            &TokenAmount::zero(),
+        )?;
+
+        match receipt.exit_code {
+            ExitCode::OK => Ok(self.return_value.take().unwrap()),
+            abort_code => Err(TokenError::ReceiverHook {
+                from: params.from,
+                to: params.to,
+                operator: params.operator,
+                amount: params.amount,
+                exit_code: abort_code,
+            }),
+        }
+    }
+}
+
+impl<T> std::ops::Drop for ReceiverHookGuard<T> {
+    fn drop(&mut self) {
+        if self.params.is_some() {
+            panic!("dropped before receiver hook was called");
+        }
+    }
+}

--- a/fil_fungible_token/src/receiver/mod.rs
+++ b/fil_fungible_token/src/receiver/mod.rs
@@ -46,10 +46,13 @@ impl ReceiverHookGuard {
     }
 }
 
-impl std::ops::Drop for ReceiverHookGuard {
+impl std::ops::Drop for ReceiverHook {
     fn drop(&mut self) {
         if !self.called {
-            panic!("dropped before receiver hook was called");
+            panic!(
+                "dropped before receiver hook was called on {:?} with {:?}",
+                self.address, self.params
+            );
         }
     }
 }

--- a/fil_fungible_token/src/receiver/mod.rs
+++ b/fil_fungible_token/src/receiver/mod.rs
@@ -9,19 +9,19 @@ use crate::token::TokenError;
 pub mod types;
 
 #[derive(Debug)]
-pub struct ReceiverHookGuard {
+pub struct ReceiverHook {
     address: Address,
     params: TokensReceivedParams,
     called: bool,
 }
 
-impl ReceiverHookGuard {
+impl ReceiverHook {
     pub fn new(address: Address, params: TokensReceivedParams) -> Self {
-        ReceiverHookGuard { address, params, called: false }
+        ReceiverHook { address, params, called: false }
     }
     pub fn call(&mut self, msg: &dyn Messaging) -> std::result::Result<(), TokenError> {
         if self.called {
-            return Err(TokenError::ReceiverHookGuardAlreadyCalled);
+            return Err(TokenError::ReceiverHookAlreadyCalled);
         }
 
         self.called = true;

--- a/fil_fungible_token/src/token/error.rs
+++ b/fil_fungible_token/src/token/error.rs
@@ -32,7 +32,7 @@ pub enum TokenError {
         exit_code: ExitCode,
     },
     #[error("receiver hook was called already")]
-    ReceiverHookGuardAlreadyCalled,
+    ReceiverHookAlreadyCalled,
     #[error("expected {address:?} to be a resolvable id address but threw {source:?} when attempting to resolve")]
     InvalidIdAddress {
         address: Address,
@@ -55,7 +55,7 @@ impl From<&TokenError> for ExitCode {
                 // distinguish it if needed (e.g. 0x0100 | exit_code)
                 *exit_code
             }
-            TokenError::ReceiverHookGuardAlreadyCalled => ExitCode::USR_ASSERTION_FAILED,
+            TokenError::ReceiverHookAlreadyCalled => ExitCode::USR_ASSERTION_FAILED,
             TokenError::InvalidIdAddress { address: _, source: _ } => ExitCode::USR_NOT_FOUND,
             TokenError::Serialization(_) => ExitCode::USR_SERIALIZATION,
             TokenError::InvalidOperator(_)

--- a/fil_fungible_token/src/token/error.rs
+++ b/fil_fungible_token/src/token/error.rs
@@ -31,6 +31,8 @@ pub enum TokenError {
         amount: TokenAmount,
         exit_code: ExitCode,
     },
+    #[error("receiver hook was called already")]
+    ReceiverHookGuardAlreadyCalled,
     #[error("expected {address:?} to be a resolvable id address but threw {source:?} when attempting to resolve")]
     InvalidIdAddress {
         address: Address,
@@ -53,6 +55,7 @@ impl From<&TokenError> for ExitCode {
                 // distinguish it if needed (e.g. 0x0100 | exit_code)
                 *exit_code
             }
+            TokenError::ReceiverHookGuardAlreadyCalled => ExitCode::USR_ASSERTION_FAILED,
             TokenError::InvalidIdAddress { address: _, source: _ } => ExitCode::USR_NOT_FOUND,
             TokenError::Serialization(_) => ExitCode::USR_SERIALIZATION,
             TokenError::InvalidOperator(_)

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -692,7 +692,7 @@ mod test {
             &mut actor_state.token_state,
         );
 
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 TREASURY,
@@ -701,6 +701,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         let state = token.state();
         // gets a read-only state
@@ -726,7 +728,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::zero());
 
         // mint some value
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 TREASURY,
@@ -735,6 +737,9 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         assert_eq!(token.total_supply(), TokenAmount::from(100));
 
         // flush token to blockstore
@@ -755,7 +760,7 @@ mod test {
         let mut token = Token::wrap(&bs, msg, 1, &mut state);
 
         // mutate state via the handle
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -764,6 +769,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         // visible via the handle
         assert_eq!(token.total_supply(), TokenAmount::from(100));
@@ -1063,9 +1070,12 @@ mod test {
 
         let mint_amount = TokenAmount::from(1_000_000);
         let burn_amount = TokenAmount::from(600_000);
-        token
+        let mut hook = token
             .mint(TOKEN_ACTOR, TREASURY, &mint_amount, Default::default(), Default::default())
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         token.burn(TREASURY, &burn_amount).unwrap();
 
         // total supply decreased
@@ -1112,9 +1122,12 @@ mod test {
 
         let mint_amount = TokenAmount::from(1_000_000);
         let burn_amount = TokenAmount::from(2_000_000);
-        token
+        let mut hook = token
             .mint(TOKEN_ACTOR, TREASURY, &mint_amount, Default::default(), Default::default())
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         token.burn(TREASURY, &burn_amount).unwrap_err();
 
         // balances and supply were unchanged
@@ -1343,7 +1356,7 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::zero());
 
         // zero-transfer should succeed
-        token
+        let mut hook = token
             .transfer(
                 secp_address,
                 ALICE,
@@ -1352,6 +1365,9 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         // balances unchanged
         assert_eq!(token.balance_of(secp_address).unwrap(), TokenAmount::zero());
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::zero());
@@ -1465,7 +1481,7 @@ mod test {
         let mut token = new_token(bs, &mut token_state);
 
         // mint 50 for the owner
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -1474,6 +1490,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         // attempt transfer 51 from owner -> receiver
         token
@@ -1649,7 +1667,7 @@ mod test {
         let mut token = new_token(bs, &mut token_state);
 
         // mint 100 for owner
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -1658,6 +1676,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         let initialised_address = &secp_address();
         token.msg.initialize_account(initialised_address).unwrap();
@@ -1699,7 +1719,7 @@ mod test {
 
         // the pubkey can be given an allowance which it can use to transfer tokens
         token.increase_allowance(ALICE, initialised_address, &TokenAmount::from(100)).unwrap();
-        token
+        let mut hook = token
             .transfer_from(
                 initialised_address,
                 ALICE,
@@ -1709,6 +1729,9 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         // balances and allowance changed
         assert_eq!(token.balance_of(ALICE).unwrap(), TokenAmount::from(99));
         assert_eq!(token.balance_of(initialised_address).unwrap(), TokenAmount::from(1));
@@ -1724,7 +1747,7 @@ mod test {
         let mut token = new_token(bs, &mut token_state);
 
         // mint 100 for owner
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -1733,6 +1756,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         // non-zero transfer by an uninitialized pubkey
         let secp_address = &secp_address();
@@ -1817,9 +1842,12 @@ mod test {
         let burn_amount = TokenAmount::from(600_000);
 
         // mint the total amount
-        token
+        let mut hook = token
             .mint(TOKEN_ACTOR, TREASURY, &mint_amount, Default::default(), Default::default())
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         // approve the burner to spend the allowance
         token.increase_allowance(TREASURY, ALICE, &approval_amount).unwrap();
         // burn the approved amount
@@ -1881,9 +1909,12 @@ mod test {
         let secp_id = token.msg.initialize_account(secp_address).unwrap();
 
         // mint the total amount
-        token
+        let mut hook = token
             .mint(TOKEN_ACTOR, TREASURY, &mint_amount, Default::default(), Default::default())
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         // approve the burner to spend the allowance
         token.increase_allowance(TREASURY, secp_address, &approval_amount).unwrap();
         // burn the approved amount
@@ -1941,9 +1972,11 @@ mod test {
         let secp_address = &secp_address();
 
         // mint the total amount
-        token
+        let mut hook = token
             .mint(TOKEN_ACTOR, TREASURY, &mint_amount, Default::default(), Default::default())
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         // cannot burn non-zero
         let err = token.burn_from(secp_address, TREASURY, &burn_amount).unwrap_err();
@@ -2000,7 +2033,7 @@ mod test {
         let mut token = new_token(bs, &mut token_state);
 
         // mint 100 for the owner
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -2009,6 +2042,9 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+
         // approve only 40 spending allowance for operator
         token.increase_allowance(ALICE, CAROL, &TokenAmount::from(40)).unwrap();
         // operator attempts makes transfer of 60 from owner -> receiver
@@ -2041,7 +2077,7 @@ mod test {
         let mut token = new_token(bs, &mut token_state);
 
         // mint 50 for the owner
-        token
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -2050,6 +2086,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         // allow 100 to be spent by operator
         token.increase_allowance(ALICE, BOB, &TokenAmount::from(100)).unwrap();
@@ -2115,10 +2153,12 @@ mod test {
                 RawBytes::default(),
             )
             .expect_err("minted below granularity");
-        token
+        let mut hook = token
             .mint(TOKEN_ACTOR, ALICE, &TokenAmount::from(0), Default::default(), Default::default())
             .unwrap();
-        token
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -2127,7 +2167,9 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
-        token
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -2136,7 +2178,9 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
-        token
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+        let mut hook = token
             .mint(
                 TOKEN_ACTOR,
                 ALICE,
@@ -2145,6 +2189,8 @@ mod test {
                 RawBytes::default(),
             )
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
 
         // Burn
         token.burn(ALICE, &TokenAmount::from(1)).expect_err("burned below granularity");
@@ -2168,12 +2214,16 @@ mod test {
         token
             .transfer(ALICE, BOB, &TokenAmount::from(1), RawBytes::default(), RawBytes::default())
             .expect_err("transfer delta below granularity");
-        token
+        let mut hook = token
             .transfer(ALICE, BOB, &TokenAmount::from(0), RawBytes::default(), RawBytes::default())
             .unwrap();
-        token
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
+        let mut hook = token
             .transfer(ALICE, BOB, &TokenAmount::from(100), RawBytes::default(), RawBytes::default())
             .unwrap();
+        token.flush().unwrap();
+        hook.call(token.msg()).unwrap();
     }
 
     #[test]
@@ -2248,7 +2298,11 @@ mod test {
             }
             // set balance if not zero (avoiding unecessary account insantiation)
             if !balance.is_zero() {
-                token.mint(from, from, balance, Default::default(), Default::default()).unwrap();
+                let mut hook = token
+                    .mint(from, from, balance, Default::default(), Default::default())
+                    .unwrap();
+                token.flush().unwrap();
+                hook.call(token.msg()).unwrap();
             }
             token
         }
@@ -2328,7 +2382,7 @@ mod test {
                 if behaviour != "OK" {
                     assert_error(res.unwrap_err(), token);
                 } else {
-                    res.expect("expect transfer to succeed");
+                    res.expect("expect transfer to succeed").call(token.msg()).unwrap();
                 }
             } else {
                 let res = token.transfer_from(
@@ -2343,7 +2397,7 @@ mod test {
                 if behaviour != "OK" {
                     assert_error(res.unwrap_err(), token);
                 } else {
-                    res.expect("expect transfer to succeed");
+                    res.expect("expect transfer to succeed").call(token.msg()).unwrap();
                 }
             }
         }

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -117,8 +117,10 @@ where
     ///
     /// The minter is implicitly defined as the caller of the actor, and must be an ID address.
     /// The mint amount must be non-negative or the method returns an error.
-    /// Returns parameters to be passed to the owner's token receiver hook,
+    ///
+    /// Returns a ReceiverHook to call the owner's token receiver hook,
     /// and the owner's new balance.
+    /// ReceiverHook must be called or it will panic and abort the transaction.
     pub fn mint(
         &mut self,
         operator: &Address,
@@ -371,12 +373,16 @@ where
     /// - The requested value MUST be non-negative
     /// - The requested value MUST NOT exceed the sender's balance
     /// - The receiving actor MUST implement a method called `tokens_received`, corresponding to the
-    /// interface specified for FRC-XXX token receiver. If the receiving hook aborts, when called,
+    /// interface specified for FRC-0046 token receiver. If the receiving hook aborts, when called,
     /// the transfer is discarded and this method returns an error
     ///
     /// Upon successful transfer:
     /// - The from balance decreases by the requested value
     /// - The to balance increases by the requested value
+    ///
+    /// Returns a ReceiverHook to call the recipient's token receiver hook,
+    /// and the updated balances.
+    /// ReceiverHook must be called or it will panic and abort the transaction.
     pub fn transfer(
         &mut self,
         from: &Address,
@@ -428,7 +434,7 @@ where
     /// - The requested value MUST be non-negative
     /// - The requested value MUST NOT exceed the sender's balance
     /// - The receiving actor MUST implement a method called `tokens_received`, corresponding to the
-    /// interface specified for FRC-XXX token receiver. If the receiving hook aborts, when called,
+    /// interface specified for FRC-0046 token receiver. If the receiving hook aborts, when called,
     /// the transfer is discarded and this method returns an error
     ///  - The operator MUST be initialised AND have an allowance not less than the requested value
     ///
@@ -436,6 +442,10 @@ where
     /// - The from balance decreases by the requested value
     /// - The to balance increases by the requested value
     /// - The owner-operator allowance decreases by the requested value
+    ///
+    /// Returns a ReceiverHook to call the recipient's token receiver hook,
+    /// and the updated allowance and balances.
+    /// ReceiverHook must be called or it will panic and abort the transaction.
     pub fn transfer_from(
         &mut self,
         operator: &Address,

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -384,7 +384,7 @@ where
         amount: &TokenAmount,
         operator_data: RawBytes,
         token_data: RawBytes,
-    ) -> Result<(TokensReceivedParams, TransferReturn)> {
+    ) -> Result<ReceiverHookGuard<TransferReturn>> {
         let amount = validate_amount(amount, "transfer", self.granularity)?;
 
         // owner-initiated transfer
@@ -411,17 +411,16 @@ where
             }
         })?;
 
-        Ok((
-            TokensReceivedParams {
-                operator: from,
-                from,
-                to: to_id,
-                amount: amount.clone(),
-                operator_data,
-                token_data,
-            },
-            res,
-        ))
+        let params = TokensReceivedParams {
+            operator: from,
+            from,
+            to: to_id,
+            amount: amount.clone(),
+            operator_data,
+            token_data,
+        };
+
+        Ok(ReceiverHookGuard::new(*to, params, res))
     }
 
     /// Transfers an amount from one address to another
@@ -445,7 +444,7 @@ where
         amount: &TokenAmount,
         operator_data: RawBytes,
         token_data: RawBytes,
-    ) -> Result<(TokensReceivedParams, TransferFromReturn)> {
+    ) -> Result<ReceiverHookGuard<TransferFromReturn>> {
         let amount = validate_amount(amount, "transfer", self.granularity)?;
         if self.same_address(operator, from) {
             return Err(TokenError::InvalidOperator(*operator));
@@ -511,17 +510,16 @@ where
             }
         })?;
 
-        Ok((
-            TokensReceivedParams {
-                operator: operator_id,
-                from,
-                to: to_id,
-                amount: amount.clone(),
-                operator_data,
-                token_data,
-            },
-            ret,
-        ))
+        let params = TokensReceivedParams {
+            operator: operator_id,
+            from,
+            to: to_id,
+            amount: amount.clone(),
+            operator_data,
+            token_data,
+        };
+
+        Ok(ReceiverHookGuard::new(*to, params, ret))
     }
 }
 

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -16,7 +16,7 @@ use self::types::BurnFromReturn;
 use self::types::BurnReturn;
 use self::types::TransferFromReturn;
 use self::types::TransferReturn;
-use crate::receiver::{types::TokensReceivedParams, ReceiverHookGuard};
+use crate::receiver::{types::TokensReceivedParams, ReceiverHook};
 use crate::runtime::messaging::{Messaging, MessagingError};
 use crate::runtime::messaging::{Result as MessagingResult, RECEIVER_HOOK_METHOD_NUM};
 use crate::token::types::MintReturn;
@@ -126,7 +126,7 @@ where
         amount: &TokenAmount,
         operator_data: RawBytes,
         token_data: RawBytes,
-    ) -> Result<(ReceiverHookGuard, MintReturn)> {
+    ) -> Result<(ReceiverHook, MintReturn)> {
         let amount = validate_amount(amount, "mint", self.granularity)?;
         // init the operator account so that its actor ID can be referenced in the receiver hook
         let operator_id = self.resolve_or_init(operator)?;
@@ -150,7 +150,7 @@ where
             token_data,
         };
 
-        Ok((ReceiverHookGuard::new(*initial_owner, params), result))
+        Ok((ReceiverHook::new(*initial_owner, params), result))
     }
 
     /// Gets the total number of tokens in existence
@@ -384,7 +384,7 @@ where
         amount: &TokenAmount,
         operator_data: RawBytes,
         token_data: RawBytes,
-    ) -> Result<(ReceiverHookGuard, TransferReturn)> {
+    ) -> Result<(ReceiverHook, TransferReturn)> {
         let amount = validate_amount(amount, "transfer", self.granularity)?;
 
         // owner-initiated transfer
@@ -420,7 +420,7 @@ where
             token_data,
         };
 
-        Ok((ReceiverHookGuard::new(*to, params), res))
+        Ok((ReceiverHook::new(*to, params), res))
     }
 
     /// Transfers an amount from one address to another
@@ -444,7 +444,7 @@ where
         amount: &TokenAmount,
         operator_data: RawBytes,
         token_data: RawBytes,
-    ) -> Result<(ReceiverHookGuard, TransferFromReturn)> {
+    ) -> Result<(ReceiverHook, TransferFromReturn)> {
         let amount = validate_amount(amount, "transfer", self.granularity)?;
         if self.same_address(operator, from) {
             return Err(TokenError::InvalidOperator(*operator));
@@ -519,7 +519,7 @@ where
             token_data,
         };
 
-        Ok((ReceiverHookGuard::new(*to, params), ret))
+        Ok((ReceiverHook::new(*to, params), ret))
     }
 }
 

--- a/testing/fil_token_integration/actors/basic_token_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_token_actor/src/lib.rs
@@ -3,7 +3,7 @@ mod util;
 use fil_fungible_token::runtime::blockstore::Blockstore;
 use fil_fungible_token::runtime::messaging::FvmMessenger;
 use fil_fungible_token::token::types::{
-    ActorError, BurnFromReturn, BurnParams, BurnReturn, DecreaseAllowanceParams, FRC46Token,
+    BurnFromReturn, BurnParams, BurnReturn, DecreaseAllowanceParams, FRC46Token,
     GetAllowanceParams, IncreaseAllowanceParams, MintReturn, Result, RevokeAllowanceParams,
     TransferFromReturn, TransferParams, TransferReturn,
 };
@@ -49,7 +49,7 @@ impl FRC46Token<RuntimeError> for BasicToken<'_> {
 
     fn transfer(&mut self, params: TransferParams) -> Result<TransferReturn, RuntimeError> {
         let operator = caller_address();
-        let mut receiver_hook = self.util.transfer(
+        let (mut hook, ret) = self.util.transfer(
             &operator,
             &params.to,
             &params.amount,
@@ -60,7 +60,8 @@ impl FRC46Token<RuntimeError> for BasicToken<'_> {
         let cid = self.util.flush()?;
         sdk::sself::set_root(&cid).unwrap();
 
-        receiver_hook.call(self.util.msg()).map_err(ActorError::from)
+        hook.call(self.util.msg())?;
+        Ok(ret)
     }
 
     fn transfer_from(
@@ -68,7 +69,7 @@ impl FRC46Token<RuntimeError> for BasicToken<'_> {
         params: fil_fungible_token::token::types::TransferFromParams,
     ) -> Result<TransferFromReturn, RuntimeError> {
         let operator = caller_address();
-        let mut receiver_hook = self.util.transfer_from(
+        let (mut hook, ret) = self.util.transfer_from(
             &operator,
             &params.from,
             &params.to,
@@ -80,7 +81,8 @@ impl FRC46Token<RuntimeError> for BasicToken<'_> {
         let cid = self.util.flush()?;
         sdk::sself::set_root(&cid).unwrap();
 
-        receiver_hook.call(self.util.msg()).map_err(ActorError::from)
+        hook.call(self.util.msg())?;
+        Ok(ret)
     }
 
     fn increase_allowance(
@@ -141,7 +143,7 @@ impl Cbor for MintParams {}
 
 impl BasicToken<'_> {
     fn mint(&mut self, params: MintParams) -> Result<MintReturn, RuntimeError> {
-        let mut receiver = self.util.mint(
+        let (mut hook, ret) = self.util.mint(
             &caller_address(),
             &params.initial_owner,
             &params.amount,
@@ -152,7 +154,9 @@ impl BasicToken<'_> {
         let cid = self.util.flush()?;
         sdk::sself::set_root(&cid).unwrap();
 
-        receiver.call(self.util.msg()).map_err(ActorError::from)
+        hook.call(self.util.msg())?;
+
+        Ok(ret)
     }
 }
 

--- a/testing/fil_token_integration/tests/mint_tokens.rs
+++ b/testing/fil_token_integration/tests/mint_tokens.rs
@@ -1,8 +1,8 @@
 use std::env;
 
-use basic_token_actor::{MintParams, MintReturn};
+use basic_token_actor::MintParams;
 use cid::Cid;
-use fil_fungible_token::token::state::TokenState;
+use fil_fungible_token::token::{state::TokenState, types::MintReturn};
 use frc42_dispatch::method_hash;
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::tester::{Account, Tester};
@@ -89,7 +89,7 @@ fn mint_tokens() {
         println!("return data was empty");
     } else {
         let mint_result: MintReturn = return_data.deserialize().unwrap();
-        println!("new total supply: {:?}", &mint_result.total_supply);
+        println!("new total supply: {:?}", &mint_result.supply);
     }
 
     // Check balance


### PR DESCRIPTION
This is part 2 of splitting the receiver hook calls out of mint and transfer operations. Implements a callable struct to be returned by mint and transfer functions which holds parameters for the hook call as well as the return data to be handed off after the receiver hook call succeeds. Guards against half-finished transactions by panicking on drop if the hook hasn't been called.

TODO:
- [x] fix tests - see https://github.com/helix-onchain/filecoin/issues/81
- [ ] ~add a transfer integration test - see https://github.com/helix-onchain/filecoin/issues/80~ will do in a new branch
- [x] add doc comments on the `ReceiverHook` type