### PR TITLE
Use anyhow backtrace feature

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2022-05-09
+nightly

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -5,6 +5,7 @@ repository = "https://github.com/helix-collective/filecoin"
 edition = "2021"
 
 [dependencies]
+anyhow = { version = "1.0.63", features = ["backtrace"] }
 basic_token_actor = { version = "0.1.0", path = "../../testing/fil_token_integration/actors/basic_token_actor" }
 cid = { version = "0.8.5", default-features = false }
 fvm = { version = "~1.1.0", default-features = false }


### PR DESCRIPTION
Recent (August 31st) update to anyhow was being pulled in by `fvm` and `fvm_integration_tests` crates. Backtraces that FVM depends on are marked as unstable and require a feature flag to enable. I've added it here so cargo will build with it and the other crates will get that as part of the build process.

Also switched from an old nightly toolchain to the latest, as we only used the old version to work around this same backtrace issue in the past