### PR TITLE
Universal token receiver

### DIFF
--- a/fil_fungible_token/src/receiver/mod.rs
+++ b/fil_fungible_token/src/receiver/mod.rs
@@ -1,7 +1,7 @@
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
 use num_traits::Zero;
-use types::{FRC46TokenReceived, ReceiveParams, FRC46_TOKEN_TYPE};
+use types::{FRC46TokenReceived, UniversalReceiverParams, FRC46_TOKEN_TYPE};
 
 use crate::runtime::messaging::{Messaging, RECEIVER_HOOK_METHOD_NUM};
 use crate::token::TokenError;
@@ -40,8 +40,10 @@ impl ReceiverHook {
 
         self.called = true;
 
-        let params =
-            ReceiveParams { type_: FRC46_TOKEN_TYPE, payload: RawBytes::serialize(&self.params)? };
+        let params = UniversalReceiverParams {
+            type_: FRC46_TOKEN_TYPE,
+            payload: RawBytes::serialize(&self.params)?,
+        };
 
         let receipt = msg.send(
             &self.address,

--- a/fil_fungible_token/src/receiver/types.rs
+++ b/fil_fungible_token/src/receiver/types.rs
@@ -1,3 +1,4 @@
+use frc42_dispatch::method_hash;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_shared::bigint::bigint_ser;
@@ -12,11 +13,14 @@ pub trait FRC46TokenReceiver {
     /// the receiving actor can immediately utilise the received funds. If the receiver wishes to
     /// reject the incoming transfer, this function should abort which will cause the token actor
     /// to rollback the transaction.
-    fn tokens_received(params: TokensReceivedParams);
+    fn receive(token_type: TokenType, params: FRC46TokenReceived);
 }
 
+pub type TokenType = u32;
+pub const FRC46_TOKEN_TYPE: TokenType = method_hash!("FRC46") as u32;
+
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
-pub struct TokensReceivedParams {
+pub struct FRC46TokenReceived {
     /// The account that the tokens are being pulled from (the token actor address itself for mint)
     pub from: ActorID,
     /// The account that the tokens are being sent to (the receiver address)
@@ -31,4 +35,11 @@ pub struct TokensReceivedParams {
     pub token_data: RawBytes,
 }
 
-impl Cbor for TokensReceivedParams {}
+impl Cbor for FRC46TokenReceived {}
+
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
+pub struct ReceiveParams {
+    pub type_: TokenType,
+    pub payload: RawBytes,
+}
+impl Cbor for ReceiveParams {}

--- a/fil_fungible_token/src/receiver/types.rs
+++ b/fil_fungible_token/src/receiver/types.rs
@@ -5,20 +5,22 @@ use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::ActorID;
 
-/// Standard interface for an actor that wishes to receive FRC-XXX tokens
-pub trait FRC46TokenReceiver {
+/// Standard interface for an actor that wishes to receive FRC-XXX tokens or other assets
+pub trait UniversalReceiver {
     /// Invoked by a token actor during pending transfer or mint to the receiver's address
     ///
     /// Within this hook, the token actor has optimistically persisted the new balance so
     /// the receiving actor can immediately utilise the received funds. If the receiver wishes to
     /// reject the incoming transfer, this function should abort which will cause the token actor
     /// to rollback the transaction.
-    fn receive(token_type: TokenType, params: FRC46TokenReceived);
+    fn receive(params: UniversalReceiverParams);
 }
 
-pub type TokenType = u32;
-pub const FRC46_TOKEN_TYPE: TokenType = method_hash!("FRC46") as u32;
+/// Type of asset received - could be tokens (FRC46 or other) or other assets
+pub type ReceiverType = u32;
+pub const FRC46_TOKEN_TYPE: ReceiverType = method_hash!("FRC46") as u32;
 
+/// Receive parameters for an FRC46 token
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct FRC46TokenReceived {
     /// The account that the tokens are being pulled from (the token actor address itself for mint)
@@ -37,9 +39,15 @@ pub struct FRC46TokenReceived {
 
 impl Cbor for FRC46TokenReceived {}
 
+/// Parameters for universal receiver
+///
+/// Actual payload varies with asset type
+/// eg: FRC46_TOKEN_TYPE will come with a payload of FRC46TokenReceived
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
-pub struct ReceiveParams {
-    pub type_: TokenType,
+pub struct UniversalReceiverParams {
+    /// Asset type
+    pub type_: ReceiverType,
+    /// Payload corresponding to asset type
     pub payload: RawBytes,
 }
-impl Cbor for ReceiveParams {}
+impl Cbor for UniversalReceiverParams {}

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -52,9 +52,9 @@ pub trait Messaging {
     fn initialize_account(&self, address: &Address) -> Result<ActorID>;
 }
 
-// the method number comes from taking the name as "TokensReceived" and applying
+// the method number comes from taking the name as "Received" and applying
 // the transformation described in https://github.com/filecoin-project/FIPs/pull/399
-pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("TokensReceived");
+pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("Received");
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FvmMessenger {}

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -54,7 +54,7 @@ pub trait Messaging {
 
 // the method number comes from taking the name as "Received" and applying
 // the transformation described in https://github.com/filecoin-project/FIPs/pull/399
-pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("Received");
+pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("Receive");
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FvmMessenger {}

--- a/fil_fungible_token/src/runtime/messaging.rs
+++ b/fil_fungible_token/src/runtime/messaging.rs
@@ -71,8 +71,7 @@ impl Messaging for FvmMessenger {
         params: &RawBytes,
         value: &TokenAmount,
     ) -> Result<Receipt> {
-        let params = RawBytes::new(fvm_ipld_encoding::to_vec(&params)?);
-        Ok(send::send(to, method, params, value.clone())?)
+        Ok(send::send(to, method, params.clone(), value.clone())?)
     }
 
     fn resolve_id(&self, address: &Address) -> Result<ActorID> {

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -16,7 +16,7 @@ use self::types::BurnFromReturn;
 use self::types::BurnReturn;
 use self::types::TransferFromReturn;
 use self::types::TransferReturn;
-use crate::receiver::{types::TokensReceivedParams, ReceiverHook};
+use crate::receiver::{types::FRC46TokenReceived, ReceiverHook};
 use crate::runtime::messaging::{Messaging, MessagingError};
 use crate::runtime::messaging::{Result as MessagingResult, RECEIVER_HOOK_METHOD_NUM};
 use crate::token::types::MintReturn;
@@ -160,7 +160,7 @@ where
         })?;
 
         // return the params we'll send to the receiver hook
-        let params = TokensReceivedParams {
+        let params = FRC46TokenReceived {
             operator: operator_id,
             from: self.msg.actor_id(),
             to: owner_id,
@@ -434,7 +434,7 @@ where
             }
         })?;
 
-        let params = TokensReceivedParams {
+        let params = FRC46TokenReceived {
             operator: from,
             from,
             to: to_id,
@@ -537,7 +537,7 @@ where
             }
         })?;
 
-        let params = TokensReceivedParams {
+        let params = FRC46TokenReceived {
             operator: operator_id,
             from,
             to: to_id,
@@ -602,7 +602,7 @@ where
     pub fn call_receiver_hook(
         &mut self,
         token_receiver: &Address,
-        params: TokensReceivedParams,
+        params: FRC46TokenReceived,
     ) -> Result<()> {
         let receipt = self.msg.send(
             token_receiver,
@@ -657,7 +657,7 @@ mod test {
     use fvm_shared::econ::TokenAmount;
     use num_traits::Zero;
 
-    use crate::receiver::types::TokensReceivedParams;
+    use crate::receiver::types::{FRC46TokenReceived, ReceiveParams};
     use crate::runtime::messaging::{FakeMessenger, Messaging, MessagingError};
     use crate::token::state::StateError;
     use crate::token::state::TokenState;
@@ -694,9 +694,10 @@ mod test {
         Token::wrap(bs, FakeMessenger::new(TOKEN_ACTOR.id().unwrap(), 6), 1, state)
     }
 
-    fn assert_last_hook_call_eq(messenger: &FakeMessenger, expected: TokensReceivedParams) {
+    fn assert_last_hook_call_eq(messenger: &FakeMessenger, expected: FRC46TokenReceived) {
         let last_called = messenger.last_message.borrow().clone().unwrap();
-        let last_called: TokensReceivedParams = last_called.deserialize().unwrap();
+        let last_called: ReceiveParams = last_called.deserialize().unwrap();
+        let last_called: FRC46TokenReceived = last_called.payload.deserialize().unwrap();
         assert_eq!(last_called, expected);
     }
 
@@ -890,7 +891,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: TOKEN_ACTOR.id().unwrap(),
                 from: TOKEN_ACTOR.id().unwrap(),
                 to: ALICE.id().unwrap(),
@@ -926,7 +927,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: TOKEN_ACTOR.id().unwrap(),
                 from: TOKEN_ACTOR.id().unwrap(),
                 to: TREASURY.id().unwrap(),
@@ -958,7 +959,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: TOKEN_ACTOR.id().unwrap(),
                 from: TOKEN_ACTOR.id().unwrap(),
                 to: ALICE.id().unwrap(),
@@ -991,7 +992,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: TOKEN_ACTOR.id().unwrap(),
                 from: TOKEN_ACTOR.id().unwrap(),
                 to: token.get_id(&secp_address).unwrap(),
@@ -1026,7 +1027,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: TOKEN_ACTOR.id().unwrap(),
                 from: TOKEN_ACTOR.id().unwrap(),
                 to: token.get_id(&bls_address).unwrap(),
@@ -1206,7 +1207,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: ALICE.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 amount: TokenAmount::from(60),
@@ -1241,7 +1242,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: ALICE.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 to: BOB.id().unwrap(),
@@ -1285,7 +1286,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: ALICE.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 to: ALICE.id().unwrap(),
@@ -1315,7 +1316,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: ALICE.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 to: ALICE.id().unwrap(),
@@ -1369,7 +1370,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: ALICE.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 to: token.get_id(secp_address).unwrap(),
@@ -1676,7 +1677,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: CAROL.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 to: BOB.id().unwrap(),
@@ -1712,7 +1713,7 @@ mod test {
         // check receiver hook was called with correct shape
         assert_last_hook_call_eq(
             &token.msg,
-            TokensReceivedParams {
+            FRC46TokenReceived {
                 operator: CAROL.id().unwrap(),
                 from: ALICE.id().unwrap(),
                 to: CAROL.id().unwrap(),

--- a/fil_fungible_token/src/token/mod.rs
+++ b/fil_fungible_token/src/token/mod.rs
@@ -657,7 +657,7 @@ mod test {
     use fvm_shared::econ::TokenAmount;
     use num_traits::Zero;
 
-    use crate::receiver::types::{FRC46TokenReceived, ReceiveParams};
+    use crate::receiver::types::{FRC46TokenReceived, UniversalReceiverParams, FRC46_TOKEN_TYPE};
     use crate::runtime::messaging::{FakeMessenger, Messaging, MessagingError};
     use crate::token::state::StateError;
     use crate::token::state::TokenState;
@@ -696,7 +696,8 @@ mod test {
 
     fn assert_last_hook_call_eq(messenger: &FakeMessenger, expected: FRC46TokenReceived) {
         let last_called = messenger.last_message.borrow().clone().unwrap();
-        let last_called: ReceiveParams = last_called.deserialize().unwrap();
+        let last_called: UniversalReceiverParams = last_called.deserialize().unwrap();
+        assert_eq!(last_called.type_, FRC46_TOKEN_TYPE);
         let last_called: FRC46TokenReceived = last_called.payload.deserialize().unwrap();
         assert_eq!(last_called, expected);
     }

--- a/testing/fil_token_integration/actors/basic_receiving_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/src/lib.rs
@@ -1,4 +1,4 @@
-//use fil_fungible_token::receiver::types::TokenReceivedParams;
+use fil_fungible_token::receiver::types::{FRC46TokenReceived, ReceiveParams, FRC46_TOKEN_TYPE};
 use frc42_dispatch::match_method;
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
 use fvm_sdk as sdk;
@@ -13,19 +13,31 @@ pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
 }
 
 #[no_mangle]
-fn invoke(_input: u32) -> u32 {
+fn invoke(input: u32) -> u32 {
+    std::panic::set_hook(Box::new(|info| {
+        sdk::vm::abort(ExitCode::USR_ASSERTION_FAILED.value(), Some(&format!("{}", info)))
+    }));
+
     let method_num = sdk::message::method_number();
     match_method!(method_num, {
         "Constructor" => {
             // this is a stateless actor so constructor does nothing
             NO_DATA_BLOCK_ID
         },
-        "TokensReceived" => {
-            // TokensReceived is passed a TokenReceivedParams
-            //let _params: TokenReceivedParams = deserialize_params(input);
+        "Received" => {
+            // Received is passed a TokenReceivedParams
+            let params: ReceiveParams = deserialize_params(input);
 
-            // decide if we care about incoming tokens or not
-            // if we don't want them, abort
+            // reject if not an FRC46 token
+            // we don't know how to inspect other payloads in this example
+            if params.type_ != FRC46_TOKEN_TYPE {
+                panic!("invalid token type, rejecting transfer");
+            }
+
+            // get token transfer data
+            let _token_params: FRC46TokenReceived = params.payload.deserialize().unwrap();
+            // TODO: inspect token_params and decide if we'll accept the transfer
+            // to reject it, we just abort (or panic, which does the same thing)
 
             NO_DATA_BLOCK_ID
         },

--- a/testing/fil_token_integration/actors/basic_receiving_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/src/lib.rs
@@ -1,4 +1,6 @@
-use fil_fungible_token::receiver::types::{FRC46TokenReceived, ReceiveParams, FRC46_TOKEN_TYPE};
+use fil_fungible_token::receiver::types::{
+    FRC46TokenReceived, UniversalReceiverParams, FRC46_TOKEN_TYPE,
+};
 use frc42_dispatch::match_method;
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
 use fvm_sdk as sdk;
@@ -24,9 +26,9 @@ fn invoke(input: u32) -> u32 {
             // this is a stateless actor so constructor does nothing
             NO_DATA_BLOCK_ID
         },
-        "Received" => {
-            // Received is passed a TokenReceivedParams
-            let params: ReceiveParams = deserialize_params(input);
+        "Receive" => {
+            // Receive is passed a UniversalReceiverParams
+            let params: UniversalReceiverParams = deserialize_params(input);
 
             // reject if not an FRC46 token
             // we don't know how to inspect other payloads in this example


### PR DESCRIPTION
Implements the universal receiver hook as detailed in [FRC-0046](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0046.md)

Also makes a change to our `FvmMessenger` which fixes an issue I had with actor-to-actor messaging. The receiver actor example can now deserialise and inspect details of incoming transfers