### PR TITLE
Dispatch update

### DIFF
--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -12,8 +12,8 @@ edition = "2021"
 fvm_ipld_encoding = { version = "0.2.2" }
 fvm_sdk = { version = "2.0.0-alpha.2", optional = true }
 fvm_shared = { version = "2.0.0-alpha.2" }
-frc42_hasher = { version = "0.1.0", path = "hasher" }
-frc42_macros = { version = "0.1.0", path = "macros" }
+frc42_hasher = { version = "0.2.0", path = "hasher" }
+frc42_macros = { version = "0.2.0", path = "macros" }
 thiserror = { version = "1.0.31" }
 
 [features]

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_hasher"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -58,7 +58,7 @@ pub enum IllegalNameErr {
 impl<T: Hasher> MethodResolver<T> {
     const CONSTRUCTOR_METHOD_NAME: &'static str = "Constructor";
     const CONSTRUCTOR_METHOD_NUMBER: u64 = 1_u64;
-    const FIRST_METHOD_NUMBER: u64 = 256_u64;
+    const FIRST_METHOD_NUMBER: u64 = 1 << 24;
     const DIGEST_CHUNK_LENGTH: usize = 4;
 
     /// Creates a MethodResolver with an instance of a hasher (blake2b by convention)

--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -19,7 +19,8 @@ impl Hasher for Blake2bSyscall {
     // fvm_sdk dependence can be removed using no_sdk feature
     #[cfg(not(feature = "no_sdk"))]
     fn hash(&self, bytes: &[u8]) -> Vec<u8> {
-        crypto::hash_blake2b(bytes).try_into().unwrap()
+        use fvm_shared::crypto::hash::SupportedHashes;
+        crypto::hash(SupportedHashes::Blake2b512, bytes)
     }
 
     // stub version that avoids fvm_sdk syscalls (eg: for proc macro, or built-in actor use)

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_macros"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention procedural macros"
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-frc42_hasher = { version = "0.1.0", path = "../hasher", features = ["no_sdk"] }
+frc42_hasher = { version = "0.2.0", path = "../hasher", features = ["no_sdk"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/frc42_dispatch/macros/example/Cargo.toml
+++ b/frc42_dispatch/macros/example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-frc42_macros = { version = "0.1.0", path = ".." }
+frc42_macros = { version = "0.2.0", path = ".." }


### PR DESCRIPTION
See issue https://github.com/helix-onchain/filecoin/issues/89

Updates the dispatch crate family to match latest updates in [FRC-0042](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md)

- [x] Updates the blake2b hash syscall to use the 512-bit version
- [x] Expands the reserved method number range from 8 bits to 24