### PR TITLE
fix: correctly key ID addresses in maps

### DIFF
--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -22,4 +22,3 @@ num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
-integer-encoding = { version = "3.0.4" }


### PR DESCRIPTION
Sorry, #113 wasn't how we actually key addresses in Filecoin today, and we should stick to the existing precedent.

The protocol is to serialize the address's payload (including its protocol).