### PR TITLE
Fix allowances map keys to be BytesKey

### DIFF
--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "1.0.0"
+version = "1.1.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc46_token/src/token/state.rs
+++ b/frc46_token/src/token/state.rs
@@ -634,7 +634,7 @@ mod test {
     use fvm_shared::{bigint::Zero, ActorID};
 
     use super::TokenState;
-    use crate::token::state::StateError;
+    use crate::token::state::{actor_id_key, StateError};
 
     #[test]
     fn it_instantiates() {
@@ -769,7 +769,8 @@ mod test {
         assert_eq!(returned_allowance, allowance);
         // the map entry is cleaned-up
         let root_map = state.get_allowances_map(bs).unwrap();
-        assert!(!root_map.contains_key(&owner).unwrap());
+        let owner_key = actor_id_key(owner);
+        assert!(!root_map.contains_key(&owner_key).unwrap());
 
         // can't set negative allowance
         let allowance = TokenAmount::from_atto(-50);

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -10,7 +10,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0-alpha.2", default-features = false }
 frcxx_nft = { path = "../../frcxx_nft" }
 frc42_dispatch = { path = "../../frc42_dispatch" }
-frc46_token = { version = "1.0.0", path = "../../frc46_token" }
+frc46_token = { version = "1.1.0", path = "../../frc46_token" }
 fvm_integration_tests = "2.0.0-alpha.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"

--- a/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-frc46_token = { version = "1.0.0", path = "../../../../frc46_token" }
+frc46_token = { version = "1.1.0", path = "../../../../frc46_token" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"

--- a/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
@@ -11,7 +11,7 @@ fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }
 fvm_sdk = { version = "2.0.0-alpha.2" }
 fvm_shared = { version = "2.0.0-alpha.2" }
-frc46_token = { version = "1.0.0", path = "../../../../frc46_token" }
+frc46_token = { version = "1.1.0", path = "../../../../frc46_token" }
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-frc46_token = { version = "1.0.0", path = "../../../../frc46_token" }
+frc46_token = { version = "1.1.0", path = "../../../../frc46_token" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }

--- a/testing/fil_token_integration/actors/test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/test_actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-frc46_token = { version = "1.0.0", path = "../../../../frc46_token" }
+frc46_token = { version = "1.1.0", path = "../../../../frc46_token" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }


### PR DESCRIPTION
This applies the change in #113 to the allowances map too. We were all too hasty making that change.

I've also extracted type aliases that would have made this harder to overlook the first time.

FYI @arajasek 