### PR TITLE
Add clone to exported types

### DIFF
--- a/frc46_token/src/token/types.rs
+++ b/frc46_token/src/token/types.rs
@@ -105,7 +105,7 @@ pub type RevokeAllowanceReturn = ();
 /// Return value after a successful mint.
 /// The mint method is not standardised, so this is merely a useful library-level type,
 /// and recommendation for token implementations.
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct MintReturn {
     /// The new balance of the owner address
     pub balance: TokenAmount,
@@ -118,7 +118,7 @@ pub struct MintReturn {
 impl Cbor for MintReturn {}
 
 /// Intermediate data used by mint_return to construct the return data
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MintIntermediate {
     /// Recipient address to use for querying balance
     pub recipient: Address,
@@ -133,7 +133,7 @@ impl RecipientData for MintIntermediate {
 }
 
 /// Instruction to transfer tokens to another address
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferParams {
     pub to: Address,
     /// A non-negative amount to transfer
@@ -143,7 +143,7 @@ pub struct TransferParams {
 }
 
 /// Return value after a successful transfer
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferReturn {
     /// The new balance of the `from` address
     pub from_balance: TokenAmount,
@@ -172,7 +172,7 @@ impl RecipientData for TransferIntermediate {
 }
 
 /// Instruction to transfer tokens between two addresses as an operator
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferFromParams {
     pub from: Address,
     pub to: Address,
@@ -183,7 +183,7 @@ pub struct TransferFromParams {
 }
 
 /// Return value after a successful delegated transfer
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferFromReturn {
     /// The new balance of the `from` address
     pub from_balance: TokenAmount,
@@ -199,7 +199,7 @@ impl Cbor for TransferFromParams {}
 impl Cbor for TransferFromReturn {}
 
 /// Intermediate data used by transfer_from_return to construct the return data
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TransferFromIntermediate {
     pub operator: Address,
     pub from: Address,
@@ -215,7 +215,7 @@ impl RecipientData for TransferFromIntermediate {
 }
 
 /// Instruction to increase an allowance between two addresses
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct IncreaseAllowanceParams {
     pub operator: Address,
     /// A non-negative amount to increase the allowance by
@@ -223,7 +223,7 @@ pub struct IncreaseAllowanceParams {
 }
 
 /// Instruction to decrease an allowance between two addresses
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct DecreaseAllowanceParams {
     pub operator: Address,
     /// A non-negative amount to decrease the allowance by
@@ -231,13 +231,13 @@ pub struct DecreaseAllowanceParams {
 }
 
 /// Instruction to revoke (set to 0) an allowance
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct RevokeAllowanceParams {
     pub operator: Address,
 }
 
 /// Params to get allowance between to addresses
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct GetAllowanceParams {
     pub owner: Address,
     pub operator: Address,
@@ -249,14 +249,14 @@ impl Cbor for RevokeAllowanceParams {}
 impl Cbor for GetAllowanceParams {}
 
 /// Instruction to burn an amount of tokens
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnParams {
     /// A non-negative amount to burn
     pub amount: TokenAmount,
 }
 
 /// The updated value after burning
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnReturn {
     /// New balance in the account after the successful burn
     pub balance: TokenAmount,
@@ -266,7 +266,7 @@ impl Cbor for BurnParams {}
 impl Cbor for BurnReturn {}
 
 /// Instruction to burn an amount of tokens from another address
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnFromParams {
     pub owner: Address,
     /// A non-negative amount to burn
@@ -274,7 +274,7 @@ pub struct BurnFromParams {
 }
 
 /// The updated value after a delegated burn
-#[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnFromReturn {
     /// New balance in the account after the successful burn
     pub balance: TokenAmount,

--- a/frcxx_nft/src/state.rs
+++ b/frcxx_nft/src/state.rs
@@ -175,7 +175,7 @@ impl NFTState {
     pub fn burn_token<BS: Blockstore>(&mut self, bs: &BS, token_id: TokenID) -> Result<()> {
         let mut token_array = self.get_token_data_amt(bs)?;
         let token_data =
-            token_array.delete(token_id)?.ok_or(StateError::TokenNotFound(token_id))?;
+            token_array.delete(token_id)?.ok_or_else(|| StateError::TokenNotFound(token_id))?;
 
         let owner_key = actor_id_key(token_data.owner);
         let mut owner_map = self.get_owner_data_hamt(bs)?;


### PR DESCRIPTION
https://github.com/helix-onchain/filecoin/issues/131

Other exported types are errors but can't add Clone to those as some of the underlying errors that are wrapped cannot be cloned (e.g. fvm_ipld_hamt::Error). 

