### PR TITLE
singular to batched state apis

### DIFF
--- a/frcxx_nft/src/lib.rs
+++ b/frcxx_nft/src/lib.rs
@@ -9,7 +9,7 @@
 use cid::Cid;
 use fvm_actor_utils::messaging::{Messaging, MessagingError};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::address::Address;
+use fvm_shared::{address::Address, ActorID};
 use state::StateError;
 use thiserror::Error;
 
@@ -76,8 +76,8 @@ where
     /// Burn a single NFT by TokenID
     ///
     /// A burnt TokenID can never be minted again
-    pub fn burn(&mut self, token_id: TokenID) -> Result<()> {
-        self.state.burn_token(&self.bs, token_id)?;
+    pub fn burn(&mut self, caller: ActorID, token_ids: &[TokenID]) -> Result<()> {
+        self.state.burn_tokens(&self.bs, caller, token_ids)?;
         Ok(())
     }
 }

--- a/testing/fil_token_integration/actors/basic_nft_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_nft_actor/src/lib.rs
@@ -41,13 +41,16 @@ fn invoke(params: u32) -> u32 {
         "Mint" => {
             let params = deserialize_params::<MintParams>(params);
             let res = handle.mint(Address::new_id(sdk::message::caller()), params.metadata_id).unwrap();
+
             let cid = handle.flush().unwrap();
             sdk::sself::set_root(&cid).unwrap();
             return_ipld(&res).unwrap()
         }
         "Burn" => {
-            let params = deserialize_params::<TokenID>(params);
-            handle.burn(params).unwrap();
+            let params = deserialize_params::<Vec<TokenID>>(params);
+            let caller = sdk::message::caller();
+            handle.burn(caller, &params).unwrap();
+
             let cid = handle.flush().unwrap();
             sdk::sself::set_root(&cid).unwrap();
             NO_DATA_BLOCK_ID

--- a/testing/fil_token_integration/tests/frcxx_nfts.rs
+++ b/testing/fil_token_integration/tests/frcxx_nfts.rs
@@ -70,7 +70,7 @@ fn it_mints_nfts() {
     assert_eq!(total_supply, 2);
 
     // Attempt to burn a non-existent token
-    let burn_params: TokenID = 100;
+    let burn_params: Vec<TokenID> = vec![100];
     let burn_params = RawBytes::serialize(&burn_params).unwrap();
     let ret_val =
         tester.call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
@@ -84,7 +84,7 @@ fn it_mints_nfts() {
     assert_eq!(total_supply, 2);
 
     // Burn the correct token
-    let burn_params: TokenID = 0;
+    let burn_params: Vec<TokenID> = vec![0];
     let burn_params = RawBytes::serialize(&burn_params).unwrap();
     let ret_val =
         tester.call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
@@ -99,7 +99,7 @@ fn it_mints_nfts() {
 
     // Cannot burn the same token again
     // Burn the correct token
-    let burn_params: TokenID = 0;
+    let burn_params: Vec<TokenID> = vec![0];
     let burn_params = RawBytes::serialize(&burn_params).unwrap();
     let ret_val =
         tester.call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));

--- a/testing/fil_token_integration/tests/nfts.rs
+++ b/testing/fil_token_integration/tests/nfts.rs
@@ -170,7 +170,7 @@ fn it_burns_tokens() {
     call_method(minter[0].1, actor_address, method_hash!("Mint"), Some(mint_params));
 
     // Attempt to burn a non-existent token
-    let burn_params: TokenID = 100;
+    let burn_params: Vec<TokenID> = vec![100];
     let burn_params = RawBytes::serialize(&burn_params).unwrap();
     let ret_val = call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     // call should fail
@@ -183,7 +183,7 @@ fn it_burns_tokens() {
     assert_eq!(total_supply, 1);
 
     // Burn the correct token
-    let burn_params: TokenID = 0;
+    let burn_params: Vec<TokenID> = vec![0];
     let burn_params = RawBytes::serialize(&burn_params).unwrap();
     let ret_val = call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     assert!(ret_val.msg_receipt.exit_code.is_success(), "{:#?}", ret_val);
@@ -197,7 +197,7 @@ fn it_burns_tokens() {
 
     // Cannot burn the same token again
     // Burn the correct token
-    let burn_params: TokenID = 0;
+    let burn_params: Vec<TokenID> = vec![0];
     let burn_params = RawBytes::serialize(&burn_params).unwrap();
     let ret_val = call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     // call should fail


### PR DESCRIPTION
Makes changes to have the APIs be batched

There's probably some more incremental improvements so that multiple state functions can be batched together without flushing the AMTs/HAMTs multiple times. 

e.g. in the use case where multiple tokens are minted then approved for an operator at once, it would be nice for the `Mint` to simply take in &mut to the HAMTs and AMTs and have the caller flush at the end of the entire transaction.

