### PR TITLE
fix: use upstream wasm-builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ test-actors: install-toolchain
 	cargo test --package greeter --package fil_token_integration_tests
 
 install-toolchain:
+	rustup update
 	rustup component add rustfmt
 	rustup component add clippy
 	rustup target add wasm32-unknown-unknown

--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -17,4 +17,4 @@ fvm_integration_tests = "2.0.0-alpha.1"
 actors-v9 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "b40284a166adb22612b4fd98ab6c2483f581d8f7" }
 
 [build-dependencies]
-wasm-builder = "3.0"
+substrate-wasm-builder = "4.0"

--- a/dispatch_examples/greeter/build.rs
+++ b/dispatch_examples/greeter/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use wasm_builder::WasmBuilder;
+    use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/frc46_token/src/receiver.rs
+++ b/frc46_token/src/receiver.rs
@@ -23,7 +23,7 @@ impl<T: RecipientData> FRC46ReceiverHook<T> for ReceiverHook<T> {
     ) -> std::result::Result<ReceiverHook<T>, ReceiverHookError> {
         Ok(ReceiverHook::new(
             address,
-            RawBytes::serialize(&frc46_params)?,
+            RawBytes::serialize(frc46_params)?,
             FRC46_TOKEN_TYPE,
             result_data,
         ))

--- a/frc46_token/src/token/mod.rs
+++ b/frc46_token/src/token/mod.rs
@@ -672,7 +672,7 @@ where
         let receipt = self.msg.send(
             token_receiver,
             RECEIVER_HOOK_METHOD_NUM,
-            &RawBytes::serialize(&params)?,
+            &RawBytes::serialize(params)?,
             &TokenAmount::zero(),
         )?;
 

--- a/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
@@ -18,4 +18,4 @@ serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
 
 [build-dependencies]
-wasm-builder = "3.0"
+substrate-wasm-builder = "4.0"

--- a/testing/fil_token_integration/actors/basic_nft_actor/build.rs
+++ b/testing/fil_token_integration/actors/basic_nft_actor/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use wasm_builder::WasmBuilder;
+    use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
@@ -13,4 +13,4 @@ fvm_sdk = { version = "2.0.0-alpha.2" }
 fvm_shared = { version = "2.0.0-alpha.2" }
 
 [build-dependencies]
-wasm-builder = "3.0"
+substrate-wasm-builder = "4.0"

--- a/testing/fil_token_integration/actors/basic_receiving_actor/build.rs
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use wasm_builder::WasmBuilder;
+    use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
@@ -18,4 +18,4 @@ serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+substrate-wasm-builder = "4.0.0"

--- a/testing/fil_token_integration/actors/basic_token_actor/build.rs
+++ b/testing/fil_token_integration/actors/basic_token_actor/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use wasm_builder::WasmBuilder;
+    use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 
 [build-dependencies]
-wasm-builder = "3.0"
+substrate-wasm-builder = "4.0"

--- a/testing/fil_token_integration/actors/basic_transfer_actor/build.rs
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use wasm_builder::WasmBuilder;
+    use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/testing/fil_token_integration/actors/test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/test_actor/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 
 [build-dependencies]
-wasm-builder = "3.0"
+substrate-wasm-builder = "4.0"

--- a/testing/fil_token_integration/actors/test_actor/build.rs
+++ b/testing/fil_token_integration/actors/test_actor/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use wasm_builder::WasmBuilder;
+    use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/testing/fil_token_integration/tests/frcxx_nfts.rs
+++ b/testing/fil_token_integration/tests/frcxx_nfts.rs
@@ -71,7 +71,7 @@ fn it_mints_nfts() {
 
     // Attempt to burn a non-existent token
     let burn_params: TokenID = 100;
-    let burn_params = RawBytes::serialize(&burn_params).unwrap();
+    let burn_params = RawBytes::serialize(burn_params).unwrap();
     let ret_val =
         tester.call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     // call should fail
@@ -85,7 +85,7 @@ fn it_mints_nfts() {
 
     // Burn the correct token
     let burn_params: TokenID = 0;
-    let burn_params = RawBytes::serialize(&burn_params).unwrap();
+    let burn_params = RawBytes::serialize(burn_params).unwrap();
     let ret_val =
         tester.call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     assert!(ret_val.msg_receipt.exit_code.is_success(), "{:#?}", ret_val);
@@ -100,7 +100,7 @@ fn it_mints_nfts() {
     // Cannot burn the same token again
     // Burn the correct token
     let burn_params: TokenID = 0;
-    let burn_params = RawBytes::serialize(&burn_params).unwrap();
+    let burn_params = RawBytes::serialize(burn_params).unwrap();
     let ret_val =
         tester.call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     // call should fail

--- a/testing/fil_token_integration/tests/nfts.rs
+++ b/testing/fil_token_integration/tests/nfts.rs
@@ -171,7 +171,7 @@ fn it_burns_tokens() {
 
     // Attempt to burn a non-existent token
     let burn_params: TokenID = 100;
-    let burn_params = RawBytes::serialize(&burn_params).unwrap();
+    let burn_params = RawBytes::serialize(burn_params).unwrap();
     let ret_val = call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     // call should fail
     assert!(!ret_val.msg_receipt.exit_code.is_success(), "{:#?}", ret_val);
@@ -184,7 +184,7 @@ fn it_burns_tokens() {
 
     // Burn the correct token
     let burn_params: TokenID = 0;
-    let burn_params = RawBytes::serialize(&burn_params).unwrap();
+    let burn_params = RawBytes::serialize(burn_params).unwrap();
     let ret_val = call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     assert!(ret_val.msg_receipt.exit_code.is_success(), "{:#?}", ret_val);
 
@@ -198,7 +198,7 @@ fn it_burns_tokens() {
     // Cannot burn the same token again
     // Burn the correct token
     let burn_params: TokenID = 0;
-    let burn_params = RawBytes::serialize(&burn_params).unwrap();
+    let burn_params = RawBytes::serialize(burn_params).unwrap();
     let ret_val = call_method(minter[0].1, actor_address, method_hash!("Burn"), Some(burn_params));
     // call should fail
     assert!(!ret_val.msg_receipt.exit_code.is_success(), "{:#?}", ret_val);


### PR DESCRIPTION
The 'wasm-builder' crate is a downstream fork. Upstream is 'substrate-wasm-builder'.