### PR TITLE
fix: allow method name start with  underscore

### DIFF
--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -51,7 +51,7 @@ pub enum MethodNameErr {
 #[derive(Error, PartialEq, Eq, Debug)]
 pub enum IllegalNameErr {
     #[error("method name doesn't start with capital letter or _")]
-    NotValidateStart,
+    NotValidStart,
     #[error("method name contains letters outside [a-zA-Z0-9_]")]
     IllegalCharacters,
 }
@@ -111,7 +111,7 @@ fn check_method_name(method_name: &str) -> Result<(), MethodNameErr> {
     // Check starts with capital letter
     let first_letter = method_name.chars().next().unwrap(); // safe because we checked for empty string
     if !(first_letter.is_ascii_uppercase() || first_letter == '_') {
-        return Err(IllegalNameErr::NotValidateStart.into());
+        return Err(IllegalNameErr:: NotValidStart.into());
     }
 
     // Check that all characters are legal
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(method_hasher.method_number("").unwrap_err(), MethodNameErr::EmptyString);
         assert_eq!(
             method_hasher.method_number("invalidMethod").unwrap_err(),
-            MethodNameErr::IllegalName(IllegalNameErr::NotValidateStart)
+            MethodNameErr::IllegalName(IllegalNameErr::NotValidStart)
         );
     }
 

--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -111,7 +111,7 @@ fn check_method_name(method_name: &str) -> Result<(), MethodNameErr> {
     // Check starts with capital letter
     let first_letter = method_name.chars().next().unwrap(); // safe because we checked for empty string
     if !(first_letter.is_ascii_uppercase() || first_letter == '_') {
-        return Err(IllegalNameErr:: NotValidStart.into());
+        return Err(IllegalNameErr::NotValidStart.into());
     }
 
     // Check that all characters are legal

--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -50,8 +50,8 @@ pub enum MethodNameErr {
 
 #[derive(Error, PartialEq, Eq, Debug)]
 pub enum IllegalNameErr {
-    #[error("method name doesn't start with capital letter")]
-    NotCapitalStart,
+    #[error("method name doesn't start with capital letter or _")]
+    NotValidateStart,
     #[error("method name contains letters outside [a-zA-Z0-9_]")]
     IllegalCharacters,
 }
@@ -110,8 +110,8 @@ fn check_method_name(method_name: &str) -> Result<(), MethodNameErr> {
 
     // Check starts with capital letter
     let first_letter = method_name.chars().next().unwrap(); // safe because we checked for empty string
-    if !first_letter.is_ascii_uppercase() {
-        return Err(IllegalNameErr::NotCapitalStart.into());
+    if !(first_letter.is_ascii_uppercase() || first_letter == '_') {
+        return Err(IllegalNameErr::NotValidateStart.into());
     }
 
     // Check that all characters are legal
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(method_hasher.method_number("").unwrap_err(), MethodNameErr::EmptyString);
         assert_eq!(
             method_hasher.method_number("invalidMethod").unwrap_err(),
-            MethodNameErr::IllegalName(IllegalNameErr::NotCapitalStart)
+            MethodNameErr::IllegalName(IllegalNameErr::NotValidateStart)
         );
     }
 

--- a/frc42_dispatch/macros/tests/build-success.rs
+++ b/frc42_dispatch/macros/tests/build-success.rs
@@ -2,6 +2,7 @@ use frc42_macros::method_hash;
 
 fn main() {
     assert_eq!(method_hash!("Method"), 0xa20642fc);
+    assert_eq!(method_hash!("_Method"), 0xeb9575aa);
 
     // method names from the example token actor
     // numbers are hashed by the python script included in the main dispatch crate

--- a/frc42_dispatch/macros/tests/naming/non-capital-start.stderr
+++ b/frc42_dispatch/macros/tests/naming/non-capital-start.stderr
@@ -4,4 +4,4 @@ error: proc macro panicked
 5 |     let _str_hash = method_hash!("noPlaceForCamelCase");
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: IllegalName(NotCapitalStart)
+  = help: message: called `Result::unwrap()` on an `Err` value: IllegalName(NotValidateStart)

--- a/frc42_dispatch/macros/tests/naming/non-capital-start.stderr
+++ b/frc42_dispatch/macros/tests/naming/non-capital-start.stderr
@@ -4,4 +4,4 @@ error: proc macro panicked
 5 |     let _str_hash = method_hash!("noPlaceForCamelCase");
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: IllegalName(NotValidateStart)
+  = help: message: called `Result::unwrap()` on an `Err` value: IllegalName(NotValidStart)


### PR DESCRIPTION
method name can start with under score

https://github.com/filecoin-project/FIPs/blob/0044af63ebaa669a286750d4b2ca61ffceff52c3/FRCs/frc-0042.md?plain=1#L78