### PR TITLE
Use Option<IpldBlock> for all message params

### DIFF
--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -14,7 +14,7 @@ fvm_shared = { version = "2.0.0" }
 cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0", default-features = false }
 fvm_integration_tests = "2.0.0-alpha.1"
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "0c8323e36fb2205eb0f27e1ec260b21d4cb59801" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "ad37e93e525d9f6f69ec9b2eba37c27ebca120f3" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0"

--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 [dependencies]
 frc42_dispatch = { path = "../../frc42_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.2"
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 
 [dev-dependencies]
 cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0", default-features = false }
 fvm_integration_tests = "2.0.0-alpha.1"
-actors-v9 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "b40284a166adb22612b4fd98ab6c2483f581d8f7" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "0c8323e36fb2205eb0f27e1ec260b21d4cb59801" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0"

--- a/dispatch_examples/greeter/src/lib.rs
+++ b/dispatch_examples/greeter/src/lib.rs
@@ -19,8 +19,8 @@ fn invoke(input: u32) -> u32 {
         "Greet" => {
             // Greet takes a name as a utf8 string
             // returns "Hello, {name}"
-            let params = sdk::message::params_raw(input).unwrap().1;
-            let params = RawBytes::new(params);
+            let params = sdk::message::params_raw(input).unwrap().unwrap();
+            let params = RawBytes::new(params.data);
             let name = params.deserialize::<String>().unwrap();
 
             let greeting = greet(&name);

--- a/dispatch_examples/greeter/tests/greet.rs
+++ b/dispatch_examples/greeter/tests/greet.rs
@@ -18,7 +18,7 @@ const DISPATCH_EXAMPLE_WASM: &str = "../../target/debug/wbuild/greeter/greeter.c
 #[test]
 fn test_greeter() {
     let blockstore = MemoryBlockstore::default();
-    let bundle_root = bundle::import_bundle(&blockstore, actors_v9::BUNDLE_CAR).unwrap();
+    let bundle_root = bundle::import_bundle(&blockstore, actors_v10::BUNDLE_CAR).unwrap();
     let mut tester =
         Tester::new(NetworkVersion::V15, StateTreeVersion::V4, bundle_root, blockstore).unwrap();
 

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 
 [dependencies]
-fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk = { version = "=2.0.0", optional = true }
+fvm_ipld_encoding = { version = "=0.2.3" }
+fvm_sdk = { version = "=2.1.0", optional = true }
 fvm_shared = { version = "2.0.0" }
 frc42_hasher = { version = "1.1.0", path = "hasher" }
 frc42_macros = { version = "1.0.0", path = "macros" }

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "=2.0.0", optional = true }
+fvm_sdk = { version = "=2.1.0", optional = true }
 fvm_shared = { version = "2.0.0" }
 thiserror = { version = "1.0.31" }
 

--- a/frc42_dispatch/src/message.rs
+++ b/frc42_dispatch/src/message.rs
@@ -1,4 +1,4 @@
-use fvm_ipld_encoding::RawBytes;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 #[cfg(not(feature = "no_sdk"))]
 use fvm_sdk::send;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ErrorNumber, receipt::Receipt};
@@ -33,7 +33,7 @@ impl<T: Hasher> MethodMessenger<T> {
         &self,
         to: &Address,
         method: &str,
-        params: RawBytes,
+        params: Option<IpldBlock>,
         value: TokenAmount,
     ) -> Result<Receipt, MethodMessengerError> {
         let method = self.method_resolver.method_number(method)?;

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -15,8 +15,8 @@ fvm_actor_utils = { version = "1.0.0", path = "../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_ipld_encoding = "0.2.2"
-fvm_sdk = "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk = "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/frc46_token/src/token/mod.rs
+++ b/frc46_token/src/token/mod.rs
@@ -5,6 +5,7 @@ pub use error::TokenError;
 use fvm_actor_utils::messaging::{Messaging, MessagingError, RECEIVER_HOOK_METHOD_NUM};
 use fvm_actor_utils::receiver::{ReceiverHook, ReceiverHookError};
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -672,7 +673,7 @@ where
         let receipt = self.msg.send(
             token_receiver,
             RECEIVER_HOOK_METHOD_NUM,
-            &RawBytes::serialize(params)?,
+            IpldBlock::serialize_cbor(&params)?,
             &TokenAmount::zero(),
         )?;
 
@@ -736,7 +737,9 @@ pub fn validate_allowance<'a>(a: &'a TokenAmount, name: &'static str) -> Result<
 mod test {
     use std::ops::Neg;
 
-    use fvm_actor_utils::messaging::{FakeMessenger, Messaging, MessagingError};
+    use fvm_actor_utils::messaging::{
+        FakeMessenger, Messaging, MessagingError, RECEIVER_HOOK_METHOD_NUM,
+    };
     use fvm_actor_utils::receiver::{ReceiverHookError, UniversalReceiverParams};
     use fvm_ipld_blockstore::MemoryBlockstore;
     use fvm_ipld_encoding::RawBytes;
@@ -782,8 +785,10 @@ mod test {
     }
 
     fn assert_last_hook_call_eq(messenger: &FakeMessenger, expected: FRC46TokenReceived) {
-        let last_called = messenger.last_message.borrow().clone().unwrap();
-        let last_called: UniversalReceiverParams = last_called.deserialize().unwrap();
+        let last_message = messenger.last_message.borrow().clone().unwrap();
+        assert_eq!(last_message.method, RECEIVER_HOOK_METHOD_NUM);
+        let last_called: UniversalReceiverParams =
+            last_message.params.unwrap().deserialize().unwrap();
         assert_eq!(last_called.type_, FRC46_TOKEN_TYPE);
         let last_called: FRC46TokenReceived = last_called.payload.deserialize().unwrap();
         assert_eq!(last_called, expected);

--- a/frcxx_nft/Cargo.toml
+++ b/frcxx_nft/Cargo.toml
@@ -12,8 +12,8 @@ fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_ipld_encoding = "0.2.2"
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 integer-encoding = { version = "3.0.4" }
 num-traits = { version = "0.2.15" }

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -12,9 +12,9 @@ anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 frc42_dispatch = { version = "1.1.0", path = "../frc42_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.2"
+fvm_ipld_encoding = "=0.2.3"
 fvm_shared = "2.0.0"
-fvm_sdk = "=2.0.0"
+fvm_sdk = "=2.1.0"
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/fvm_actor_utils/src/messaging.rs
+++ b/fvm_actor_utils/src/messaging.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use frc42_dispatch::method_hash;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::Error as IpldError;
-use fvm_ipld_encoding::RawBytes;
 use fvm_sdk::{actor, message, send, sys::ErrorNumber};
 use fvm_shared::error::ExitCode;
 use fvm_shared::receipt::Receipt;
@@ -61,7 +61,7 @@ pub trait Messaging {
         &self,
         to: &Address,
         method: MethodNum,
-        params: &RawBytes,
+        params: Option<IpldBlock>,
         value: &TokenAmount,
     ) -> Result<Receipt>;
 
@@ -129,10 +129,10 @@ impl Messaging for FvmMessenger {
         &self,
         to: &Address,
         method: MethodNum,
-        params: &RawBytes,
+        params: Option<IpldBlock>,
         value: &TokenAmount,
     ) -> Result<Receipt> {
-        Ok(send::send(to, method, params.clone(), value.clone())?)
+        Ok(send::send(to, method, params, value.clone())?)
     }
 
     fn resolve_id(&self, address: &Address) -> Result<ActorID> {
@@ -148,11 +148,19 @@ impl Messaging for FvmMessenger {
     }
 }
 
+/// A fake message
+///
+#[derive(Debug, Clone)]
+pub struct FakeMessage {
+    pub params: Option<IpldBlock>,
+    pub method: MethodNum,
+}
+
 /// A fake method caller
 ///
 #[derive(Debug)]
 pub struct FakeMessenger {
-    pub last_message: RefCell<Option<RawBytes>>,
+    pub last_message: RefCell<Option<FakeMessage>>,
     address_resolver: RefCell<FakeAddressResolver>,
     actor_id: ActorID,
     abort_next_send: RefCell<bool>,
@@ -189,11 +197,11 @@ impl Messaging for FakeMessenger {
     fn send(
         &self,
         _to: &Address,
-        _method: MethodNum,
-        params: &RawBytes,
+        method: MethodNum,
+        params: Option<IpldBlock>,
         _value: &TokenAmount,
     ) -> Result<Receipt> {
-        self.last_message.borrow_mut().replace(params.clone());
+        self.last_message.borrow_mut().replace(FakeMessage { params, method });
 
         if *self.abort_next_send.borrow() {
             self.abort_next_send.replace(false);

--- a/fvm_actor_utils/src/receiver/mod.rs
+++ b/fvm_actor_utils/src/receiver/mod.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
@@ -122,7 +123,12 @@ impl<T: RecipientData> ReceiverHook<T> {
         let receipt = msg.send(
             &self.address,
             RECEIVER_HOOK_METHOD_NUM,
-            &RawBytes::serialize(&params)?,
+            IpldBlock::serialize_cbor(&params).map_err(|e| {
+                ReceiverHookError::IpldEncoding(fvm_ipld_encoding::Error {
+                    description: e.to_string(),
+                    protocol: fvm_ipld_encoding::CodecProtocol::Cbor,
+                })
+            })?,
             &TokenAmount::zero(),
         )?;
 

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 
 [dev-dependencies]
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "0c8323e36fb2205eb0f27e1ec260b21d4cb59801" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "ad37e93e525d9f6f69ec9b2eba37c27ebca120f3" }
 basic_nft_actor = {path = "actors/basic_nft_actor"}
 basic_receiving_actor = { path = "actors/basic_receiving_actor" }
 basic_token_actor = { path = "actors/basic_token_actor" }

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -9,17 +9,17 @@ anyhow = { version = "1.0.63", features = ["backtrace"] }
 cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0", default-features = false }
 frcxx_nft = { path = "../../frcxx_nft" }
-frc42_dispatch = { path = "../../frc42_dispatch" }
+frc42_dispatch = { version = "1.1.0", path = "../../frc42_dispatch" }
 frc46_token = { version = "2.0.0", path = "../../frc46_token" }
 fvm_integration_tests = "2.0.0-alpha.1"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.2"
+fvm_ipld_encoding = "=0.2.3"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 
 [dev-dependencies]
-actors-v9 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "b40284a166adb22612b4fd98ab6c2483f581d8f7" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "0c8323e36fb2205eb0f27e1ec260b21d4cb59801" }
 basic_nft_actor = {path = "actors/basic_nft_actor"}
 basic_receiving_actor = { path = "actors/basic_receiving_actor" }
 basic_token_actor = { path = "actors/basic_token_actor" }

--- a/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
@@ -9,8 +9,8 @@ frcxx_nft = { path = "../../../../frcxx_nft" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.2"
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = "2.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/basic_nft_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_nft_actor/src/lib.rs
@@ -179,8 +179,8 @@ pub struct MintParams {
 
 /// Grab the incoming parameters and convert from RawBytes to deserialized struct
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
-    let params = sdk::message::params_raw(params).unwrap().1;
-    let params = RawBytes::new(params);
+    let params = sdk::message::params_raw(params).unwrap().unwrap();
+    let params = RawBytes::new(params.data);
     params.deserialize().unwrap()
 }
 

--- a/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
@@ -9,8 +9,8 @@ frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.2"
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 
 [build-dependencies]

--- a/testing/fil_token_integration/actors/basic_receiving_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/src/lib.rs
@@ -9,8 +9,8 @@ use sdk::NO_DATA_BLOCK_ID;
 
 /// Grab the incoming parameters and convert from RawBytes to deserialized struct
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
-    let params = sdk::message::params_raw(params).unwrap().1;
-    let params = RawBytes::new(params);
+    let params = sdk::message::params_raw(params).unwrap().unwrap();
+    let params = RawBytes::new(params.data);
     params.deserialize().unwrap()
 }
 

--- a/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 cid = { version = "0.8.5", default-features = false }
 fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
-fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
 num-traits = { version = "0.2.15" }

--- a/testing/fil_token_integration/actors/basic_token_actor/src/util.rs
+++ b/testing/fil_token_integration/actors/basic_token_actor/src/util.rs
@@ -23,7 +23,7 @@ pub fn caller_address() -> Address {
 
 /// Grab the incoming parameters and convert from RawBytes to deserialized struct
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
-    let params = sdk::message::params_raw(params).unwrap().1;
-    let params = RawBytes::new(params);
+    let params = sdk::message::params_raw(params).unwrap().unwrap();
+    let params = RawBytes::new(params.data);
     params.deserialize().unwrap()
 }

--- a/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
@@ -9,8 +9,8 @@ frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
-fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "=0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
@@ -10,8 +10,8 @@ frc42_dispatch = { path = "../../../../frc42_dispatch" }
 frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
 fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
-fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/frcxx_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frcxx_test_actor/Cargo.toml
@@ -10,8 +10,8 @@ frc42_dispatch = { path = "../../../../frc42_dispatch" }
 frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
 fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
-fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk =  "=2.0.0"
+fvm_ipld_encoding = "0.2.3"
+fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0-alpha.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/frcxx_test_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/frcxx_test_actor/src/lib.rs
@@ -3,6 +3,7 @@ use frcxx_nft::receiver::FRCXXTokenReceived;
 use frcxx_nft::types::TransferParams;
 use frcxx_nft::{receiver::FRCXX_TOKEN_TYPE, state::TokenID};
 use fvm_actor_utils::receiver::UniversalReceiverParams;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{
     de::DeserializeOwned,
     tuple::{Deserialize_tuple, Serialize_tuple},
@@ -15,8 +16,8 @@ use serde::{Deserialize, Serialize};
 
 /// Grab the incoming parameters and convert from RawBytes to deserialized struct
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
-    let params = sdk::message::params_raw(params).unwrap().1;
-    let params = RawBytes::new(params);
+    let params = sdk::message::params_raw(params).unwrap().unwrap();
+    let params = RawBytes::new(params.data);
     params.deserialize().unwrap()
 }
 
@@ -69,7 +70,7 @@ fn transfer(token: Address, to: Address, token_ids: Vec<TokenID>, operator_data:
     let receipt = sdk::send::send(
         &token,
         method_hash!("Transfer"),
-        RawBytes::serialize(&transfer_params).unwrap(),
+        IpldBlock::serialize_cbor(&transfer_params).unwrap(),
         TokenAmount::zero(),
     )
     .unwrap();
@@ -82,7 +83,7 @@ fn burn(token: Address, token_ids: Vec<TokenID>) -> u32 {
     let receipt = sdk::send::send(
         &token,
         method_hash!("Burn"),
-        RawBytes::serialize(token_ids).unwrap(),
+        IpldBlock::serialize_cbor(&token_ids).unwrap(),
         TokenAmount::zero(),
     )
     .unwrap();

--- a/testing/fil_token_integration/tests/common/mod.rs
+++ b/testing/fil_token_integration/tests/common/mod.rs
@@ -60,7 +60,7 @@ pub fn load_actor_wasm(path: &str) -> Vec<u8> {
 /// Construct a Tester with the provided blockstore
 /// mainly cuts down on noise with importing the built-in actor bundle and network/state tree versions
 pub fn construct_tester<BS: Blockstore + Clone, E: Externs>(blockstore: &BS) -> Tester<BS, E> {
-    let bundle_root = bundle::import_bundle(&blockstore, actors_v9::BUNDLE_CAR).unwrap();
+    let bundle_root = bundle::import_bundle(&blockstore, actors_v10::BUNDLE_CAR).unwrap();
 
     Tester::new(NetworkVersion::V15, StateTreeVersion::V4, bundle_root, blockstore.clone()).unwrap()
 }

--- a/testing/fil_token_integration/tests/frc46_tokens.rs
+++ b/testing/fil_token_integration/tests/frc46_tokens.rs
@@ -25,7 +25,7 @@ const BASIC_RECEIVER_ACTOR_WASM: &str =
 #[test]
 fn it_mints_tokens() {
     let blockstore = MemoryBlockstore::default();
-    let bundle_root = bundle::import_bundle(&blockstore, actors_v9::BUNDLE_CAR).unwrap();
+    let bundle_root = bundle::import_bundle(&blockstore, actors_v10::BUNDLE_CAR).unwrap();
     let mut tester =
         Tester::new(NetworkVersion::V15, StateTreeVersion::V4, bundle_root, blockstore.clone())
             .unwrap();


### PR DESCRIPTION
This PR:
- Updates FVM SDK and ipld_encoding
- Refactors to start using `Option<IpldBlock>` for message parameters