### PR TITLE
FRC-0042 method name can start with underscore

### DIFF
--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -50,8 +50,8 @@ pub enum MethodNameErr {
 
 #[derive(Error, PartialEq, Eq, Debug)]
 pub enum IllegalNameErr {
-    #[error("method name doesn't start with capital letter")]
-    NotCapitalStart,
+    #[error("method name doesn't start with capital letter or _")]
+    IllegalStartingCharacter,
     #[error("method name contains letters outside [a-zA-Z0-9_]")]
     IllegalCharacters,
 }
@@ -108,10 +108,10 @@ fn check_method_name(method_name: &str) -> Result<(), MethodNameErr> {
         return Err(MethodNameErr::EmptyString);
     }
 
-    // Check starts with capital letter
+    // Check starts with capital letter or an underscore
     let first_letter = method_name.chars().next().unwrap(); // safe because we checked for empty string
-    if !first_letter.is_ascii_uppercase() {
-        return Err(IllegalNameErr::NotCapitalStart.into());
+    if !first_letter.is_ascii_uppercase() && first_letter != "_" {
+        return Err(IllegalNameErr::IllegalStartingCharacter.into());
     }
 
     // Check that all characters are legal
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(method_hasher.method_number("").unwrap_err(), MethodNameErr::EmptyString);
         assert_eq!(
             method_hasher.method_number("invalidMethod").unwrap_err(),
-            MethodNameErr::IllegalName(IllegalNameErr::NotCapitalStart)
+            MethodNameErr::IllegalName(IllegalNameErr::IllegalStartingCharacter)
         );
     }
 


### PR DESCRIPTION
Method names should be able to start with an underscore. This is detailed in the spec https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md