### PR TITLE
chore: deps: lock to FVM SDK 2.0.0

### DIFF
--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 frc42_dispatch = { path = "../../frc42_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 
 [dev-dependencies]

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -16,7 +16,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/frcxx_nft/Cargo.toml
+++ b/frcxx_nft/Cargo.toml
@@ -13,7 +13,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 integer-encoding = { version = "3.0.4" }
 num-traits = { version = "0.2.15" }

--- a/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
@@ -10,7 +10,7 @@ frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_actor_utils = { version = "0.1.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = "2.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
@@ -10,7 +10,7 @@ frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_actor_utils = { version = "0.1.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 
 [build-dependencies]

--- a/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
@@ -9,7 +9,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm_actor_utils = { version = "0.1.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 frc46_token = { version = "1.1.0", path = "../../../../frc46_token" }
 num-traits = { version = "0.2.15" }

--- a/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
@@ -10,7 +10,7 @@ frc42_dispatch = { path = "../../../../frc42_dispatch" }
 fvm_actor_utils = { version = "0.1.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
@@ -11,7 +11,7 @@ frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
 fvm_actor_utils = { version = "0.1.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/frcxx_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frcxx_test_actor/Cargo.toml
@@ -11,7 +11,7 @@ frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
 fvm_actor_utils = { version = "0.1.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = { version = "0.2.2" }
-fvm_sdk = { version = "2.0.0-alpha.2" }
+fvm_sdk =  "=2.0.0"
 fvm_shared = { version = "2.0.0-alpha.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }


### PR DESCRIPTION
`main` is currently broken because it's auto-updating the SDK to v2.1.0