### PR TITLE
Release frc46_token 3.0.0 etc

### DIFF
--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "1.1.0"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -12,7 +12,7 @@ edition = "2021"
 fvm_ipld_encoding = { version = "=0.2.3" }
 fvm_sdk = { version = "=2.1.0", optional = true }
 fvm_shared = { version = "2.0.0" }
-frc42_hasher = { version = "1.1.0", path = "hasher" }
+frc42_hasher = { version = "1.2.0", path = "hasher" }
 frc42_macros = { version = "1.0.0", path = "macros" }
 thiserror = { version = "1.0.31" }
 

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_hasher"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-frc42_hasher = { version = "1.1.0", path = "../hasher", features = ["no_sdk"] }
+frc42_hasher = { version = "1.2.0", path = "../hasher", features = ["no_sdk"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "2.0.0"
+version = "3.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
+frc42_dispatch = { version = "2.0.0", path = "../frc42_dispatch" }
+fvm_actor_utils = { version = "2.0.0", path = "../fvm_actor_utils" }
+
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = { version = "1.1.0", path = "../frc42_dispatch" }
-fvm_actor_utils = { version = "1.0.0", path = "../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }

--- a/frcxx_nft/Cargo.toml
+++ b/frcxx_nft/Cargo.toml
@@ -5,9 +5,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 frc42_dispatch = { path = "../frc42_dispatch" }
-fvm_actor_utils = { version = "1.0.0", path = "../fvm_actor_utils" }
+fvm_actor_utils = { path = "../fvm_actor_utils" }
+
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_hamt = "0.5.1"

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "fvm_actor_utils"
 description = "Utils for authoring native actors for the Filecoin Virtual Machine"
-version = "1.0.0"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm"]
 repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
+frc42_dispatch = { version = "2.0.0", path = "../frc42_dispatch" }
+
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = { version = "1.1.0", path = "../frc42_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "=0.2.3"
 fvm_shared = "2.0.0"

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -5,12 +5,13 @@ repository = "https://github.com/helix-collective/filecoin"
 edition = "2021"
 
 [dependencies]
+frcxx_nft = { path = "../../frcxx_nft" }
+frc42_dispatch = { path = "../../frc42_dispatch" }
+frc46_token = { path = "../../frc46_token" }
+
 anyhow = { version = "1.0.63", features = ["backtrace"] }
 cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0", default-features = false }
-frcxx_nft = { path = "../../frcxx_nft" }
-frc42_dispatch = { version = "1.1.0", path = "../../frc42_dispatch" }
-frc46_token = { version = "2.0.0", path = "../../frc46_token" }
 fvm_integration_tests = "2.0.0-alpha.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "=0.2.3"

--- a/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frcxx_nft = { path = "../../../../frcxx_nft" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
-fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
+frcxx_nft = { path = "../../../../frcxx_nft" }
+fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
+
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "=0.2.3"
 fvm_sdk =  "=2.1.0"

--- a/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
-frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
-fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
+frc46_token = { path = "../../../../frc46_token" }
+frcxx_nft = { path = "../../../../frcxx_nft" }
+fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
+
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "=0.2.3"
-fvm_sdk =  "=2.1.0"
+fvm_sdk = "=2.1.0"
 fvm_shared = { version = "2.0.0" }
 
 [build-dependencies]

--- a/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
@@ -5,13 +5,14 @@ repository = "https://github.com/helix-collective/filecoin"
 edition = "2021"
 
 [dependencies]
+frc46_token = { path = "../../../../frc46_token" }
+fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
+
 cid = { version = "0.8.5", default-features = false }
-fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "=0.2.3"
 fvm_sdk =  "=2.1.0"
 fvm_shared = { version = "2.0.0" }
-frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cid = { version = "0.8.5", default-features = false }
-frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
-fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
+frc46_token = { path = "../../../../frc46_token" }
+fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
+
+cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "=0.2.3"
 fvm_sdk =  "=2.1.0"

--- a/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cid = { version = "0.8.5", default-features = false }
-frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
+frc46_token = { path = "../../../../frc46_token" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
-frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
-fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
+frcxx_nft = { path = "../../../../frcxx_nft" }
+fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
+
+cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "0.2.3"
 fvm_sdk =  "=2.1.0"

--- a/testing/fil_token_integration/actors/frcxx_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frcxx_test_actor/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cid = { version = "0.8.5", default-features = false }
-frc46_token = { version = "2.0.0", path = "../../../../frc46_token" }
+frc46_token = { path = "../../../../frc46_token" }
+fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
 frc42_dispatch = { path = "../../../../frc42_dispatch" }
-frcxx_nft = { version = "0.1.0", path = "../../../../frcxx_nft" }
-fvm_actor_utils = { version = "1.0.0", path = "../../../../fvm_actor_utils" }
+frcxx_nft = { path = "../../../../frcxx_nft" }
+
+cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "0.2.3"
 fvm_sdk =  "=2.1.0"


### PR DESCRIPTION
Removed unnecessary version specifiers in dependencies of unpublished testing crates.

I have published these crates.