### PR TITLE
update fungible token to use new shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,3 @@ members = [
     "testing/fil_token_integration/actors/frc46_test_actor",
     "testing/fil_token_integration/actors/frcxx_test_actor"
 ]
-
-[patch.crates-io]
-# tracking issue: https://github.com/bitvecto-rs/funty/issues/7
-funty = { git = "https://github.com/bitvecto-rs/funty/", rev = "7ef0d890fbcd8b3def1635ac1a877fc298488446" }

--- a/frcxx_nft/src/lib.rs
+++ b/frcxx_nft/src/lib.rs
@@ -8,9 +8,9 @@
 
 use cid::Cid;
 use fvm_actor_utils::{
+    messaging::MessagingError,
     receiver::ReceiverHook,
     runtime::Runtime,
-    util::MessagingError,
     util::{ActorError, ActorHelper},
 };
 use fvm_ipld_blockstore::Blockstore;

--- a/fvm_actor_utils/src/lib.rs
+++ b/fvm_actor_utils/src/lib.rs
@@ -3,5 +3,5 @@ pub mod blockstore;
 pub mod messaging;
 pub mod receiver;
 
-pub mod runtime;
+pub mod syscalls;
 pub mod util;

--- a/fvm_actor_utils/src/messaging.rs
+++ b/fvm_actor_utils/src/messaging.rs
@@ -1,16 +1,16 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
+
+
 
 use frc42_dispatch::method_hash;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::Error as IpldError;
-use fvm_sdk::{actor, message, send, sys::ErrorNumber};
+use fvm_sdk::{send, sys::ErrorNumber};
 use fvm_shared::error::ExitCode;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::MethodNum;
-use fvm_shared::METHOD_SEND;
-use fvm_shared::{address::Address, econ::TokenAmount, ActorID};
-use num_traits::Zero;
+
+use fvm_shared::{address::Address, econ::TokenAmount};
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, MessagingError>;
@@ -51,12 +51,8 @@ impl From<&MessagingError> for ExitCode {
     }
 }
 
-// TODO: remove this trait as it is superseded by the fvm_actor_utils::util::Actor trait
 /// An abstraction used to send messages to other actors
 pub trait Messaging {
-    /// Returns the address of the current actor as an ActorID
-    fn actor_id(&self) -> ActorID;
-
     /// Sends a message to an actor
     fn send(
         &self,
@@ -65,53 +61,6 @@ pub trait Messaging {
         params: Option<IpldBlock>,
         value: &TokenAmount,
     ) -> Result<Receipt>;
-
-    /// Attempts to resolve the given address to its ID address form
-    ///
-    /// Returns MessagingError::AddressNotResolved if the address could not be resolved
-    fn resolve_id(&self, address: &Address) -> Result<ActorID>;
-
-    /// Creates an account at a pubkey address and returns the ID address
-    ///
-    /// Returns MessagingError::AddressNotInitialized if the address could not be created
-    fn initialize_account(&self, address: &Address) -> Result<ActorID>;
-
-    /// Resolves an address to an ID address, sending a message to initialize an account there if
-    /// it doesn't exist
-    ///
-    /// If the account cannot be created, this function returns MessagingError::AddressNotInitialized
-    fn resolve_or_init(&self, address: &Address) -> Result<ActorID> {
-        let id = match self.resolve_id(address) {
-            Ok(addr) => addr,
-            Err(MessagingError::AddressNotResolved(_e)) => self.initialize_account(address)?,
-            Err(e) => return Err(e),
-        };
-        Ok(id)
-    }
-
-    /// Attempts to compare two addresses, seeing if they would resolve to the same Actor without
-    /// actually instantiating accounts for them
-    ///
-    /// If a and b are of the same type, simply do an equality check. Otherwise, attempt to resolve
-    /// to an ActorID and compare
-    fn same_address(&self, address_a: &Address, address_b: &Address) -> bool {
-        let protocol_a = address_a.protocol();
-        let protocol_b = address_b.protocol();
-        if protocol_a == protocol_b {
-            address_a == address_b
-        } else {
-            // attempt to resolve both to ActorID
-            let id_a = match self.resolve_id(address_a) {
-                Ok(id) => id,
-                Err(_) => return false,
-            };
-            let id_b = match self.resolve_id(address_b) {
-                Ok(id) => id,
-                Err(_) => return false,
-            };
-            id_a == id_b
-        }
-    }
 }
 
 /// This method number comes from taking the name as "Receive" and applying
@@ -122,10 +71,6 @@ pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("Receive");
 pub struct FvmMessenger {}
 
 impl Messaging for FvmMessenger {
-    fn actor_id(&self) -> ActorID {
-        message::receiver()
-    }
-
     fn send(
         &self,
         to: &Address,
@@ -134,282 +79,5 @@ impl Messaging for FvmMessenger {
         value: &TokenAmount,
     ) -> Result<Receipt> {
         Ok(send::send(to, method, params, value.clone())?)
-    }
-
-    fn resolve_id(&self, address: &Address) -> Result<ActorID> {
-        actor::resolve_address(address).ok_or(MessagingError::AddressNotResolved(*address))
-    }
-
-    fn initialize_account(&self, address: &Address) -> Result<ActorID> {
-        if let Err(e) = send::send(address, METHOD_SEND, Default::default(), TokenAmount::zero()) {
-            return Err(e.into());
-        }
-
-        actor::resolve_address(address).ok_or(MessagingError::AddressNotInitialized(*address))
-    }
-}
-
-/// A fake message
-///
-#[derive(Debug, Clone)]
-pub struct FakeMessage {
-    pub params: Option<IpldBlock>,
-    pub method: MethodNum,
-}
-
-/// A fake method caller
-///
-#[derive(Debug)]
-pub struct FakeMessenger {
-    pub last_message: RefCell<Option<FakeMessage>>,
-    address_resolver: RefCell<FakeAddressResolver>,
-    actor_id: ActorID,
-    abort_next_send: RefCell<bool>,
-}
-
-/// A mocked messenger that can be used to interact with other Actors
-///
-/// Can be used to test behaviour when other Actors abort when handling messages
-impl FakeMessenger {
-    /// Creates a new FakeMessenger with a given set of initialized accounts
-    ///
-    /// first_usable_actor_id is the first ActorID that has not been already allocated to an address
-    /// i.e. in test fixtures where it may be useful to have statically allocated ID addresses, they
-    /// should all have an ActorID strictly below first_usable_actor_id
-    pub fn new(actor_id: ActorID, first_usable_actor_id: ActorID) -> Self {
-        Self {
-            actor_id,
-            address_resolver: RefCell::new(FakeAddressResolver::new(first_usable_actor_id)),
-            last_message: Default::default(),
-            abort_next_send: RefCell::new(false),
-        }
-    }
-
-    pub fn abort_next_send(&mut self) {
-        self.abort_next_send.replace(true);
-    }
-}
-
-impl Messaging for FakeMessenger {
-    fn actor_id(&self) -> ActorID {
-        self.actor_id
-    }
-
-    fn send(
-        &self,
-        _to: &Address,
-        method: MethodNum,
-        params: Option<IpldBlock>,
-        _value: &TokenAmount,
-    ) -> Result<Receipt> {
-        self.last_message.borrow_mut().replace(FakeMessage { params, method });
-
-        if *self.abort_next_send.borrow() {
-            self.abort_next_send.replace(false);
-            return Ok(Receipt {
-                exit_code: ExitCode::USR_UNSPECIFIED,
-                gas_used: 0,
-                return_data: Default::default(),
-            });
-        }
-
-        Ok(Receipt { exit_code: ExitCode::OK, return_data: Default::default(), gas_used: 0 })
-    }
-
-    fn resolve_id(&self, address: &Address) -> Result<ActorID> {
-        self.address_resolver.borrow().resolve_id(address)
-    }
-
-    fn initialize_account(&self, address: &Address) -> Result<ActorID> {
-        self.address_resolver.borrow_mut().initialize_account(address)
-    }
-}
-
-/// A fake address resolver that keeps track of addresses that keeps track of which addresses have
-/// been initialised and their corresponding IDs
-#[derive(Debug)]
-pub struct FakeAddressResolver {
-    next_actor_id: ActorID,
-    initialized_accounts: HashMap<Address, ActorID>,
-}
-
-impl FakeAddressResolver {
-    pub fn new(next_actor_id: ActorID) -> Self {
-        Self { next_actor_id, initialized_accounts: HashMap::new() }
-    }
-
-    pub fn initialize_account(&mut self, address: &Address) -> Result<ActorID> {
-        match address.payload() {
-            fvm_shared::address::Payload::ID(id) => {
-                panic!("attempting to initialise an already resolved id {id}")
-            }
-            fvm_shared::address::Payload::Secp256k1(_) => Ok(self._initialize_address(address)?),
-            fvm_shared::address::Payload::BLS(_) => Ok(self._initialize_address(address)?),
-            fvm_shared::address::Payload::Actor(_) => {
-                Err(MessagingError::AddressNotInitialized(*address))
-            }
-        }
-    }
-
-    pub fn resolve_id(&self, address: &Address) -> Result<ActorID> {
-        // return an initialised address if it has been initialized before
-        if self.initialized_accounts.contains_key(address) {
-            return Ok(self.initialized_accounts[address]);
-        }
-
-        // else resolve it if it is an id address
-        match address.payload() {
-            fvm_shared::address::Payload::ID(id) => Ok(*id),
-            _ => Err(MessagingError::AddressNotResolved(*address)),
-        }
-    }
-
-    fn _initialize_address(&mut self, address: &Address) -> Result<ActorID> {
-        let actor_id = self.next_actor_id;
-        self.next_actor_id += 1;
-        self.initialized_accounts.insert(*address, actor_id);
-        Ok(actor_id)
-    }
-}
-
-#[cfg(test)]
-mod test_address_resolver {
-    use fvm_shared::address::{Address, BLS_PUB_LEN};
-
-    use super::FakeAddressResolver;
-
-    /// Returns a static secp256k1 address
-    fn secp_address(id: u8) -> Address {
-        let key = vec![id; 65];
-        Address::new_secp256k1(key.as_slice()).unwrap()
-    }
-
-    /// Returns a static BLS address
-    fn bls_address(id: u8) -> Address {
-        let key = vec![id; BLS_PUB_LEN];
-        Address::new_bls(key.as_slice()).unwrap()
-    }
-
-    // Returns a new Actor address, that is uninitializable by the FakeMessenger
-    fn actor_address(id: u8) -> Address {
-        Address::new_actor(&[id])
-    }
-
-    #[test]
-    fn it_creates_incrementing_addresses() {
-        let mut ar = FakeAddressResolver::new(1);
-        let secp_1 = &secp_address(1);
-        let secp_2 = &secp_address(2);
-        let bls_1 = &bls_address(1);
-        let bls_2 = &bls_address(2);
-        let actor_1 = &actor_address(1);
-
-        // none resolvable initially
-        ar.resolve_id(secp_1).unwrap_err();
-        ar.resolve_id(secp_2).unwrap_err();
-        ar.resolve_id(bls_1).unwrap_err();
-        ar.resolve_id(bls_2).unwrap_err();
-        ar.resolve_id(actor_1).unwrap_err();
-
-        // creates new actor ids
-        assert_eq!(ar.initialize_account(secp_1).unwrap(), 1);
-        assert_eq!(ar.initialize_account(secp_2).unwrap(), 2);
-        assert_eq!(ar.initialize_account(bls_1).unwrap(), 3);
-        assert_eq!(ar.initialize_account(bls_2).unwrap(), 4);
-
-        // cannot assign actor id to an account address
-        ar.initialize_account(actor_1).unwrap_err();
-    }
-
-    #[test]
-    fn it_retrieves_initialised_addresses() {
-        let mut ar = FakeAddressResolver::new(1);
-        let secp_1 = &secp_address(1);
-
-        // cannot initially resolve
-        ar.resolve_id(secp_1).unwrap_err();
-
-        // initialize it
-        ar.initialize_account(secp_1).unwrap();
-
-        // resolves now
-        assert_eq!(ar.resolve_id(secp_1).unwrap(), 1);
-    }
-
-    #[test]
-    fn it_doesnt_collide_with_reserved_address_space() {
-        let mut ar = FakeAddressResolver::new(10);
-        let secp_1 = &secp_address(1);
-
-        // cannot initially resolve
-        ar.resolve_id(secp_1).unwrap_err();
-
-        // initialize it
-        ar.initialize_account(secp_1).unwrap();
-
-        // resolves now
-        assert_eq!(ar.resolve_id(secp_1).unwrap(), 10);
-    }
-
-    #[test]
-    fn it_resolves_id_addresses() {
-        let ar = FakeAddressResolver::new(10);
-        let id_address = &Address::new_id(4);
-
-        // cannot initially resolve
-        assert_eq!(ar.resolve_id(id_address).unwrap(), 4);
-    }
-}
-
-#[cfg(test)]
-mod test_fake_messenger {
-    /// Returns a static secp256k1 address
-    fn secp_address(id: u8) -> Address {
-        let key = vec![id; 65];
-        Address::new_secp256k1(key.as_slice()).unwrap()
-    }
-
-    /// Returns a static BLS address
-    fn bls_address(id: u8) -> Address {
-        let key = vec![id; BLS_PUB_LEN];
-        Address::new_bls(key.as_slice()).unwrap()
-    }
-
-    // Returns a new Actor address, that is uninitializable by the FakeMessenger
-    fn actor_address(id: u8) -> Address {
-        Address::new_actor(&[id])
-    }
-    use fvm_shared::address::{Address, BLS_PUB_LEN};
-
-    use crate::messaging::{FakeMessenger, Messaging};
-
-    /// Simple test checking that the fake messenger uses the address resolver to resolve addresses
-    /// The resolution of addresses is tested in the test_address_resolver module
-    #[test]
-    fn it_resolves_addresses_with_fake_address_resolver() {
-        let m = FakeMessenger::new(0, 1);
-        let secp_1 = &secp_address(1);
-        let secp_2 = &secp_address(2);
-        let bls_1 = &bls_address(1);
-        let bls_2 = &bls_address(2);
-        let actor_1 = &actor_address(1);
-
-        // none resolvable initially
-        m.resolve_id(secp_1).unwrap_err();
-        m.resolve_id(secp_2).unwrap_err();
-        m.resolve_id(bls_1).unwrap_err();
-        m.resolve_id(bls_2).unwrap_err();
-        m.resolve_id(actor_1).unwrap_err();
-
-        // creates new actor ids
-        assert_eq!(m.initialize_account(secp_1).unwrap(), 1);
-        assert_eq!(m.initialize_account(secp_2).unwrap(), 2);
-        assert_eq!(m.initialize_account(bls_1).unwrap(), 3);
-        assert_eq!(m.initialize_account(bls_2).unwrap(), 4);
-
-        // cannot assign actor id to an account address
-        m.initialize_account(actor_1).unwrap_err();
-
-        assert_eq!(m.resolve_id(&Address::new_id(1)).unwrap(), 1);
     }
 }

--- a/fvm_actor_utils/src/messaging.rs
+++ b/fvm_actor_utils/src/messaging.rs
@@ -1,6 +1,3 @@
-
-
-
 use frc42_dispatch::method_hash;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::Error as IpldError;
@@ -8,9 +5,7 @@ use fvm_sdk::{send, sys::ErrorNumber};
 use fvm_shared::error::ExitCode;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::MethodNum;
-
 use fvm_shared::{address::Address, econ::TokenAmount};
-
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, MessagingError>;

--- a/fvm_actor_utils/src/receiver/mod.rs
+++ b/fvm_actor_utils/src/receiver/mod.rs
@@ -171,8 +171,6 @@ mod test {
     use super::{ReceiverHook, RecipientData};
     use crate::{runtime::TestRuntime, util::ActorHelper};
 
-    // FIXME: cleanup
-    // const TOKEN_ACTOR: Address = Address::new_id(1);
     const ALICE: Address = Address::new_id(2);
 
     struct TestReturn;

--- a/fvm_actor_utils/src/receiver/mod.rs
+++ b/fvm_actor_utils/src/receiver/mod.rs
@@ -169,7 +169,7 @@ mod test {
     use fvm_shared::address::Address;
 
     use super::{ReceiverHook, RecipientData};
-    use crate::{runtime::TestRuntime, util::ActorHelper};
+    use crate::{syscalls::FakeSyscalls, util::ActorRuntime};
 
     const ALICE: Address = Address::new_id(2);
 
@@ -191,10 +191,10 @@ mod test {
     #[test]
     fn calls_hook() {
         let mut hook = generate_hook();
-        let util = ActorHelper::<TestRuntime, MemoryBlockstore>::new_test_helper();
-        assert!(util.runtime.last_message.borrow().is_none());
+        let util = ActorRuntime::<FakeSyscalls, MemoryBlockstore>::new_test_helper();
+        assert!(util.syscalls.last_message.borrow().is_none());
         hook.call(&util).unwrap();
-        assert!(util.runtime.last_message.borrow().is_some());
+        assert!(util.syscalls.last_message.borrow().is_some());
     }
 
     #[test]

--- a/fvm_actor_utils/src/syscalls/fake_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fake_syscalls.rs
@@ -7,7 +7,7 @@ use fvm_shared::{
     ActorID,
 };
 
-use super::Runtime;
+use super::Syscalls;
 
 #[derive(Clone, Default, Debug)]
 pub struct TestMessage {
@@ -17,7 +17,7 @@ pub struct TestMessage {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct TestRuntime {
+pub struct FakeSyscalls {
     /// The root of the calling actor
     pub root: Cid,
     /// The f0 ID of the calling actor
@@ -34,7 +34,7 @@ pub struct TestRuntime {
     pub abort_next_send: RefCell<bool>,
 }
 
-impl Runtime for TestRuntime {
+impl Syscalls for FakeSyscalls {
     fn root(&self) -> Result<Cid, super::NoStateError> {
         Ok(self.root)
     }

--- a/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
@@ -3,13 +3,13 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_sdk;
 use fvm_shared::{address::Address, MethodNum};
 
-use super::Runtime;
+use super::Syscalls;
 
 /// Runtime that delegates to fvm_sdk allowing actors to be deployed on-chain
 #[derive(Default, Debug, Clone, Copy)]
-pub struct FvmRuntime {}
+pub struct FvmSyscalls {}
 
-impl Runtime for FvmRuntime {
+impl Syscalls for FvmSyscalls {
     fn root(&self) -> Result<cid::Cid, super::NoStateError> {
         fvm_sdk::sself::root().map_err(|_| super::NoStateError)
     }

--- a/fvm_actor_utils/src/syscalls/mod.rs
+++ b/fvm_actor_utils/src/syscalls/mod.rs
@@ -5,21 +5,21 @@ use fvm_shared::{
 };
 use thiserror::Error;
 
-mod fvm_runtime;
-pub use fvm_runtime::FvmRuntime;
+mod fvm_syscalls;
+pub use fvm_syscalls::FvmSyscalls;
 
-mod test_runtime;
-pub use test_runtime::TestRuntime;
+mod fake_syscalls;
+pub use fake_syscalls::FakeSyscalls;
 
 /// Copied to avoid linking against `fvm_sdk` for non-WASM targets
 #[derive(Copy, Clone, Debug, Error)]
 #[error("actor does not exist in state-tree")]
 pub struct NoStateError;
 
-/// Runtime is the abstract interface that an FVM actor uses to interact with the rest of the system
+/// The Syscalls trait defines methods available to the actor from its execution environment.
 ///
-/// The methods available on runtime are a subset of the methods exported by `fvm_sdk`
-pub trait Runtime {
+/// The methods available are a subset of the methods exported by `fvm_sdk`
+pub trait Syscalls {
     /// Get the IPLD root CID. Fails if the actor doesn't have state (before the first call to
     /// `set_root` and after actor deletion).
     fn root(&self) -> Result<Cid, NoStateError>;

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -10,10 +10,10 @@ use num_traits::Zero;
 use thiserror::Error;
 
 use crate::messaging::{Messaging, MessagingError, Result as MessagingResult};
-use crate::runtime::FvmRuntime;
-use crate::runtime::NoStateError;
-use crate::runtime::Runtime;
-use crate::runtime::TestRuntime;
+use crate::syscalls::FakeSyscalls;
+use crate::syscalls::FvmSyscalls;
+use crate::syscalls::NoStateError;
+use crate::syscalls::Syscalls;
 
 #[derive(Error, Clone, Debug)]
 pub enum ActorError {
@@ -23,28 +23,31 @@ pub enum ActorError {
 
 type ActorResult<T> = std::result::Result<T, ActorError>;
 
-/// ActorHelper contains utils to help access the underlying execution environment (runtime and blockstore)
+/// ActorRuntime provides access to system resources via Syscalls and the Blockstore
+///
+/// It provides higher level utilities than raw syscalls for actors to use to interact with the
+/// IPLD layer and the FVM runtime (e.g. messaging other actors)
 #[derive(Clone, Debug)]
-pub struct ActorHelper<R: Runtime, BS: Blockstore> {
-    pub runtime: R,
+pub struct ActorRuntime<S: Syscalls, BS: Blockstore> {
+    pub syscalls: S,
     pub blockstore: BS,
 }
 
-impl<R: Runtime, BS: Blockstore> ActorHelper<R, BS> {
-    pub fn new_test_helper() -> ActorHelper<TestRuntime, MemoryBlockstore> {
-        ActorHelper { runtime: TestRuntime::default(), blockstore: MemoryBlockstore::default() }
+impl<S: Syscalls, BS: Blockstore> ActorRuntime<S, BS> {
+    pub fn new_test_helper() -> ActorRuntime<FakeSyscalls, MemoryBlockstore> {
+        ActorRuntime { syscalls: FakeSyscalls::default(), blockstore: MemoryBlockstore::default() }
     }
 
-    pub fn new_fvm_helper() -> ActorHelper<FvmRuntime, crate::blockstore::Blockstore> {
-        ActorHelper {
-            runtime: FvmRuntime::default(),
+    pub fn new_fvm_helper() -> ActorRuntime<FvmSyscalls, crate::blockstore::Blockstore> {
+        ActorRuntime {
+            syscalls: FvmSyscalls::default(),
             blockstore: crate::blockstore::Blockstore::default(),
         }
     }
 
     /// Returns the address of the current actor as an ActorID
     pub fn actor_id(&self) -> ActorID {
-        self.runtime.receiver()
+        self.syscalls.receiver()
     }
 
     /// Sends a message to an actor
@@ -55,14 +58,14 @@ impl<R: Runtime, BS: Blockstore> ActorHelper<R, BS> {
         params: Option<IpldBlock>,
         value: TokenAmount,
     ) -> MessagingResult<Receipt> {
-        Ok(self.runtime.send(to, method, params, value)?)
+        Ok(self.syscalls.send(to, method, params, value)?)
     }
 
     /// Attempts to resolve the given address to its ID address form
     ///
     /// Returns MessagingError::AddressNotResolved if the address could not be resolved
     pub fn resolve_id(&self, address: &Address) -> MessagingResult<ActorID> {
-        self.runtime.resolve_address(address).ok_or(MessagingError::AddressNotResolved(*address))
+        self.syscalls.resolve_address(address).ok_or(MessagingError::AddressNotResolved(*address))
     }
 
     /// Resolves an address to an ID address, sending a message to initialize an account there if
@@ -92,7 +95,7 @@ impl<R: Runtime, BS: Blockstore> ActorHelper<R, BS> {
 
     /// Get the root cid of the actor's state
     pub fn root_cid(&self) -> ActorResult<Cid> {
-        Ok(self.runtime.root().map_err(|_err| NoStateError)?)
+        Ok(self.syscalls.root().map_err(|_err| NoStateError)?)
     }
 
     /// Attempts to compare two addresses, seeing if they would resolve to the same Actor without
@@ -125,7 +128,7 @@ impl<R: Runtime, BS: Blockstore> ActorHelper<R, BS> {
 }
 
 /// Convenience impl encapsulating the blockstore functionality
-impl<R: Runtime, BS: Blockstore> Blockstore for ActorHelper<R, BS> {
+impl<S: Syscalls, BS: Blockstore> Blockstore for ActorRuntime<S, BS> {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         self.blockstore.get(k)
     }
@@ -135,7 +138,7 @@ impl<R: Runtime, BS: Blockstore> Blockstore for ActorHelper<R, BS> {
     }
 }
 
-impl<R: Runtime, BS: Blockstore> Messaging for ActorHelper<R, BS> {
+impl<S: Syscalls, BS: Blockstore> Messaging for ActorRuntime<S, BS> {
     fn send(
         &self,
         to: &Address,
@@ -143,7 +146,7 @@ impl<R: Runtime, BS: Blockstore> Messaging for ActorHelper<R, BS> {
         params: Option<IpldBlock>,
         value: &fvm_shared::econ::TokenAmount,
     ) -> crate::messaging::Result<Receipt> {
-        let res = self.runtime.send(to, method, params, value.clone());
+        let res = self.syscalls.send(to, method, params, value.clone());
         Ok(res?)
     }
 }

--- a/testing/fil_token_integration/actors/basic_nft_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_nft_actor/src/lib.rs
@@ -8,7 +8,7 @@ use frcxx_nft::{
     NFT,
 };
 use fvm_actor_utils::{
-    blockstore::Blockstore, messaging::FvmMessenger, runtime::FvmRuntime, util::ActorHelper,
+    blockstore::Blockstore, messaging::FvmMessenger, syscalls::FvmSyscalls, util::ActorRuntime,
 };
 use fvm_ipld_encoding::{
     de::DeserializeOwned,
@@ -36,7 +36,7 @@ fn invoke(params: u32) -> u32 {
     // let actor_helper = FvmActor {};
     let messenger = FvmMessenger::default();
     let root_cid = sdk::sself::root().unwrap();
-    let helpers = ActorHelper::<FvmRuntime, Blockstore>::new_fvm_helper();
+    let helpers = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_helper();
     let mut state = NFTState::load(&helpers, &root_cid).unwrap();
     let mut handle = NFT::wrap(helpers, &mut state);
 

--- a/testing/fil_token_integration/actors/basic_token_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_token_actor/src/lib.rs
@@ -9,8 +9,8 @@ use frc46_token::token::types::{
 };
 use frc46_token::token::Token;
 use fvm_actor_utils::blockstore::Blockstore;
-use fvm_actor_utils::runtime::FvmRuntime;
-use fvm_actor_utils::util::ActorHelper;
+use fvm_actor_utils::syscalls::FvmSyscalls;
+use fvm_actor_utils::util::ActorRuntime;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
@@ -25,7 +25,7 @@ use util::{caller_address, deserialize_params, RuntimeError};
 
 struct BasicToken<'state> {
     /// Default token helper impl
-    util: Token<'state, FvmRuntime, Blockstore>,
+    util: Token<'state, FvmSyscalls, Blockstore>,
 }
 
 /// Implementation of the token API in a FVM actor
@@ -65,7 +65,7 @@ impl FRC46Token<RuntimeError> for BasicToken<'_> {
         let cid = self.util.flush()?;
         sdk::sself::set_root(&cid).unwrap();
 
-        let hook_ret = hook.call(&self.util.helper)?;
+        let hook_ret = hook.call(&self.util.runtime)?;
 
         self.reload(&cid)?;
         let ret = self.util.transfer_return(hook_ret)?;
@@ -90,7 +90,7 @@ impl FRC46Token<RuntimeError> for BasicToken<'_> {
         let cid = self.util.flush()?;
         sdk::sself::set_root(&cid).unwrap();
 
-        let hook_ret = hook.call(&self.util.helper)?;
+        let hook_ret = hook.call(&self.util.runtime)?;
 
         self.reload(&cid)?;
         let ret = self.util.transfer_from_return(hook_ret)?;
@@ -174,7 +174,7 @@ impl BasicToken<'_> {
         let cid = self.util.flush()?;
         sdk::sself::set_root(&cid).unwrap();
 
-        let hook_ret = hook.call(&self.util.helper)?;
+        let hook_ret = hook.call(&self.util.runtime)?;
 
         self.reload(&cid)?;
         let ret = self.util.mint_return(hook_ret)?;
@@ -216,9 +216,9 @@ pub fn invoke(params: u32) -> u32 {
         rest => {
             let root_cid = sdk::sself::root().unwrap();
 
-            let helper = ActorHelper::<FvmRuntime, Blockstore>::new_fvm_helper();
+            let helper = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_helper();
             let mut token_state =
-                Token::<FvmRuntime, Blockstore>::load_state(helper.bs(), &root_cid).unwrap();
+                Token::<FvmSyscalls, Blockstore>::load_state(helper.bs(), &root_cid).unwrap();
 
             let mut token_actor = BasicToken { util: Token::wrap(helper, 1, &mut token_state) };
 
@@ -317,8 +317,8 @@ pub fn invoke(params: u32) -> u32 {
 }
 
 fn constructor() -> u32 {
-    let helper = ActorHelper::<FvmRuntime, Blockstore>::new_fvm_helper();
-    let mut token_state = Token::<FvmRuntime, Blockstore>::create_state(helper.bs()).unwrap();
+    let helper = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_helper();
+    let mut token_state = Token::<FvmSyscalls, Blockstore>::create_state(helper.bs()).unwrap();
     let mut token = Token::wrap(helper, 1, &mut token_state);
     let cid = token.flush().unwrap();
     sdk::sself::set_root(&cid).unwrap();


### PR DESCRIPTION
Pulled these changes out separately from https://github.com/helix-onchain/filecoin/pull/167 as it's quite noisy and we might not want to head in this direction (i.e. change the existing fungible token APIs)

This PR de-dupes some code in the fvm_actor_utils package while maintaining lightweight alternatives (i.e. Messaging trait) to the full-blown `ActorHelper` utility.

However, i think it's a good indicator that the ActorHelper is a useful abstraction if it simplifies the existing code (which I feel it does)