### PR TITLE
Update the v10 actors testing bundle

### DIFF
--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -14,7 +14,7 @@ fvm_shared = { version = "2.0.0" }
 cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0", default-features = false }
 fvm_integration_tests = "2.0.0-alpha.1"
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "fc03ddd4df8b91171d7c262fd9f7a2eebf5f76d9" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "e3f3db964434dc354ea52d08c8778b4beabce5f7" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0"

--- a/frc46_factory_token/Cargo.toml
+++ b/frc46_factory_token/Cargo.toml
@@ -22,7 +22,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm = { version = "2.0.0", default-features = false }
 fvm_integration_tests = "2.0.0"
 frc46_test_actor = { path = "../testing/fil_token_integration/actors/frc46_test_actor" }
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "fc03ddd4df8b91171d7c262fd9f7a2eebf5f76d9" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "e3f3db964434dc354ea52d08c8778b4beabce5f7" }
 
 [build-dependencies]
 wasm-builder = "3.0"

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 
 [dev-dependencies]
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "fc03ddd4df8b91171d7c262fd9f7a2eebf5f76d9" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "e3f3db964434dc354ea52d08c8778b4beabce5f7" }
 basic_nft_actor = {path = "actors/basic_nft_actor"}
 basic_receiving_actor = { path = "actors/basic_receiving_actor" }
 basic_token_actor = { path = "actors/basic_token_actor" }


### PR DESCRIPTION
Points to the latest commit in the builtin actors integ branch (https://github.com/filecoin-project/builtin-actors/pull/987), which in turn points back to the latest commit in `main` here. 

This reference should be updated once more when https://github.com/filecoin-project/builtin-actors/pull/987 lands.