### PR TITLE
Release frc42_dispatch 3.0.0, frc_46 3.1.0, fvm_actor_utils 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,3 @@ members = [
     "frc46_factory_token",
     "frc46_factory_token/token_impl"
 ]
-
-[patch.crates-io]
-# tracking issue: https://github.com/bitvecto-rs/funty/issues/7
-funty = { git = "https://github.com/bitvecto-rs/funty/", rev = "7ef0d890fbcd8b3def1635ac1a877fc298488446" }

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "2.0.0"
+version = "3.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_hasher"
-version = "1.2.0"
+version = "1.3.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc46_factory_token/Cargo.toml
+++ b/frc46_factory_token/Cargo.toml
@@ -10,7 +10,7 @@ frc46_token = { path = "../frc46_token" }
 fvm_actor_utils = { path = "../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk = "=2.2.0"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/frc46_factory_token/Cargo.toml
+++ b/frc46_factory_token/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 cid = { version = "0.8.5", default-features = false }
 frc42_dispatch = { path = "../frc42_dispatch" }
 frc46_token = { path = "../frc46_token" }
-fvm_actor_utils = { version = "2.0.0", path = "../fvm_actor_utils" }
+fvm_actor_utils = { path = "../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 fvm_sdk = { version = "2.0.0" }

--- a/frc46_factory_token/token_impl/Cargo.toml
+++ b/frc46_factory_token/token_impl/Cargo.toml
@@ -11,7 +11,7 @@ frc46_token = { path = "../../frc46_token" }
 fvm_actor_utils = { path = "../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
-fvm_sdk = { version = "2.0.0" }
+fvm_sdk = "=2.2.0"
 fvm_shared = { version = "2.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/frc46_factory_token/token_impl/Cargo.toml
+++ b/frc46_factory_token/token_impl/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 cid = { version = "0.8.5", default-features = false }
 frc42_dispatch = { path = "../../frc42_dispatch" }
 frc46_token = { path = "../../frc46_token" }
-fvm_actor_utils = { version = "2.0.0", path = "../../fvm_actor_utils" }
+fvm_actor_utils = { path = "../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 fvm_sdk = { version = "2.0.0" }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "3.0.0"
+version = "3.1.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
-frc42_dispatch = { version = "2.0.0", path = "../frc42_dispatch" }
-fvm_actor_utils = { version = "2.0.0", path = "../fvm_actor_utils" }
+frc42_dispatch = { version = "3.0.0", path = "../frc42_dispatch" }
+fvm_actor_utils = { version = "3.0.0", path = "../fvm_actor_utils" }
 
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "fvm_actor_utils"
 description = "Utils for authoring native actors for the Filecoin Virtual Machine"
-version = "2.0.0"
+version = "3.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm"]
 repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
-frc42_dispatch = { version = "2.0.0", path = "../frc42_dispatch" }
+frc42_dispatch = { version = "3.0.0", path = "../frc42_dispatch" }
 
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }


### PR DESCRIPTION
To release will follow these steps: https://github.com/helix-onchain/filecoin/issues/181

In future, this should be automated so that anyone with sufficient permissions on the repository can publish releases easily.