### PR TITLE
update hamt and amt libraries

### DIFF
--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -14,8 +14,8 @@ fvm_actor_utils = { version = "3.0.0", path = "../fvm_actor_utils" }
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_hamt = "0.5.1"
-fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
+fvm_ipld_hamt = "0.6.1"
+fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_encoding = "=0.2.3"
 fvm_sdk = "=2.2.0"
 fvm_shared = { version = "2.0.0" }

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -11,8 +11,8 @@ fvm_actor_utils = { path = "../fvm_actor_utils" }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_hamt = "0.5.1"
-fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
+fvm_ipld_hamt = "0.6.1"
+fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_encoding = "=0.2.3"
 fvm_sdk =  "=2.2.0"
 fvm_shared = { version = "2.0.0" }


### PR DESCRIPTION
To prepare for work adding new features to the AMT and HAMT libraries, first upgrade to the latest published crates

Using the latest version numbers also makes patching dependencies from `ref-fvm` easier to iterate on the AMT code locally.