### PR TITLE
FRC46 factory token unit test coverage, ActorRuntime improvements

### DIFF
--- a/frc46_factory_token/src/lib.rs
+++ b/frc46_factory_token/src/lib.rs
@@ -13,7 +13,8 @@ fn token_invoke(method_num: u64, params: u32) -> Result<u32, RuntimeError> {
     match_method!(method_num, {
         "Constructor" => {
             let params = deserialize_params(params);
-            construct_token(params)
+            let runtime = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_runtime();
+            construct_token(runtime, params)
         }
         "Mint" => {
             let root_cid = fvm_sdk::sself::root()?;

--- a/frc46_factory_token/src/lib.rs
+++ b/frc46_factory_token/src/lib.rs
@@ -1,4 +1,7 @@
 use frc42_dispatch::match_method;
+use fvm_actor_utils::{
+    blockstore::Blockstore, syscalls::fvm_syscalls::FvmSyscalls, util::ActorRuntime,
+};
 use fvm_sdk::NO_DATA_BLOCK_ID;
 use fvm_shared::error::ExitCode;
 use token_impl::{
@@ -15,13 +18,15 @@ fn token_invoke(method_num: u64, params: u32) -> Result<u32, RuntimeError> {
         "Mint" => {
             let root_cid = fvm_sdk::sself::root()?;
             let params: MintParams = deserialize_params(params);
-            let mut token_actor = FactoryToken::load(&root_cid)?;
+            let runtime = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_runtime();
+            let mut token_actor = FactoryToken::load(runtime, &root_cid)?;
             let res = token_actor.mint(params)?;
             return_ipld(&res)
         }
         "DisableMint" => {
             let root_cid = fvm_sdk::sself::root()?;
-            let mut token_actor = FactoryToken::load(&root_cid)?;
+            let runtime = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_runtime();
+            let mut token_actor = FactoryToken::load(runtime, &root_cid)?;
             // disable minting forever
             token_actor.disable_mint()?;
             // save state
@@ -33,7 +38,8 @@ fn token_invoke(method_num: u64, params: u32) -> Result<u32, RuntimeError> {
         _ => {
             let root_cid = fvm_sdk::sself::root()?;
 
-            let mut token_actor = FactoryToken::load(&root_cid)?;
+            let runtime = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_runtime();
+            let mut token_actor = FactoryToken::load(runtime, &root_cid)?;
 
             let res = frc46_invoke(method_num, params, &mut token_actor, |token| {
                 // `token` is passed through from the original token provided in the function call

--- a/frc46_factory_token/tests/factory_token.rs
+++ b/frc46_factory_token/tests/factory_token.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 mod common;
 use common::{construct_tester, TestHelpers, TokenHelpers};
-use token_impl::{ConstructorParams, FactoryToken};
+use token_impl::ConstructorParams;
 
 const FACTORY_TOKEN_ACTOR_WASM: &str =
     "../target/debug/wbuild/frc46_factory_token/frc46_factory_token.compact.wasm";
@@ -66,13 +66,8 @@ fn factory_token() {
 
     let operator: [Account; 1] = tester.create_accounts().unwrap();
 
-    let initial_token_state = FactoryToken::new(&blockstore, String::new(), String::new(), 1, None);
-
-    // install actors required for our test: a token actor and one instance of the test actor
-    let token_actor =
-        tester.install_actor_with_state(FACTORY_TOKEN_ACTOR_WASM, 10000, initial_token_state);
-
-    // create a couple test actors
+    // install actors required for our test: token actor and a couple test actors
+    let token_actor = tester.install_actor_stateless(FACTORY_TOKEN_ACTOR_WASM, 10000);
     let alice = tester.install_actor_stateless(TEST_ACTOR_WASM, 10010);
     let bob = tester.install_actor_stateless(TEST_ACTOR_WASM, 10020);
 

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -311,10 +311,7 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> FactoryToken<S, BS> {
     }
 
     pub fn token(&mut self) -> Token<'_, S, BS> {
-        // NOTE: cloning an ActorRuntime when using a MemoryBlockstore will lead to changes disappearing as it spawns a new, separate blockstore.
-        // use SharedMemoryBlockstore from fvm_actor_utils for unit testing as it shares a single store between cloned instances
-        // fvm_actor_utils::Blockstore is fine too as it's a syscall wrapper that holds no state (so every instance operates on the one underlying store)
-        Token::wrap(self.runtime.clone(), self.state.granularity, &mut self.state.token)
+        Token::wrap(&self.runtime, self.state.granularity, &mut self.state.token)
     }
 
     pub fn load(runtime: ActorRuntime<S, BS>, cid: &Cid) -> Result<Self, RuntimeError> {

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -142,7 +142,7 @@ pub struct FactoryTokenState {
     pub minter: Option<ActorID>,
 }
 
-pub struct FactoryToken<S: Syscalls + Clone, BS: Blockstore + Clone> {
+pub struct FactoryToken<S: Syscalls, BS: Blockstore> {
     runtime: ActorRuntime<S, BS>,
     state: FactoryTokenState,
 }
@@ -285,7 +285,7 @@ pub struct MintParams {
     pub operator_data: RawBytes,
 }
 
-impl<S: Syscalls + Clone, BS: Blockstore + Clone> FactoryToken<S, BS> {
+impl<S: Syscalls, BS: Blockstore> FactoryToken<S, BS> {
     pub fn new(
         runtime: ActorRuntime<S, BS>,
         name: String,

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -539,7 +539,13 @@ where
 
 #[cfg(test)]
 mod test {
-    use frc46_token::token::{types::{FRC46Token, TransferParams, GetAllowanceParams, IncreaseAllowanceParams, TransferFromParams}, TokenError};
+    use frc46_token::token::{
+        types::{
+            FRC46Token, GetAllowanceParams, IncreaseAllowanceParams, TransferFromParams,
+            TransferParams,
+        },
+        TokenError,
+    };
     use fvm_actor_utils::{
         shared_blockstore::SharedMemoryBlockstore, syscalls::fake_syscalls::FakeSyscalls,
         util::ActorRuntime,
@@ -746,11 +752,13 @@ mod test {
         assert_eq!(token.total_supply(), TokenAmount::from_whole(10));
 
         // now transfer half of them from ALICE to BOB
-        let ret = token.transfer(TransferParams {
-            to: BOB,
-            amount: TokenAmount::from_whole(5),
-            operator_data: RawBytes::default(),
-        }).unwrap();
+        let ret = token
+            .transfer(TransferParams {
+                to: BOB,
+                amount: TokenAmount::from_whole(5),
+                operator_data: RawBytes::default(),
+            })
+            .unwrap();
 
         assert_eq!(ret.from_balance, TokenAmount::from_whole(5));
         assert_eq!(ret.to_balance, TokenAmount::from_whole(5));
@@ -780,20 +788,24 @@ mod test {
         // set caller ID to BOB so we can set ALICE as an operator on that account
         token.runtime.syscalls.set_caller_id(token.runtime.resolve_id(&BOB).unwrap());
         // set allowance
-        token.increase_allowance(IncreaseAllowanceParams {
-            operator: ALICE,
-            increase: TokenAmount::from_whole(10),
-        }).unwrap();
+        token
+            .increase_allowance(IncreaseAllowanceParams {
+                operator: ALICE,
+                increase: TokenAmount::from_whole(10),
+            })
+            .unwrap();
         // set caller ID back to alice to make the transfer
         token.runtime.syscalls.set_caller_id(token.runtime.resolve_id(&ALICE).unwrap());
 
         // now transfer half of them from ALICE to BOB
-        let ret = token.transfer_from(TransferFromParams {
-            from: BOB,
-            to: ALICE,
-            amount: TokenAmount::from_whole(5),
-            operator_data: RawBytes::default(),
-        }).unwrap();
+        let ret = token
+            .transfer_from(TransferFromParams {
+                from: BOB,
+                to: ALICE,
+                amount: TokenAmount::from_whole(5),
+                operator_data: RawBytes::default(),
+            })
+            .unwrap();
 
         // check balances and supply
         assert_eq!(ret.from_balance, TokenAmount::from_whole(5));
@@ -802,7 +814,10 @@ mod test {
         assert_eq!(token.balance_of(BOB).unwrap(), TokenAmount::from_whole(5));
         // check allowance
         assert_eq!(ret.allowance, TokenAmount::from_whole(5));
-        assert_eq!(token.allowance(GetAllowanceParams { owner: BOB, operator: ALICE }).unwrap(), TokenAmount::from_whole(5));
+        assert_eq!(
+            token.allowance(GetAllowanceParams { owner: BOB, operator: ALICE }).unwrap(),
+            TokenAmount::from_whole(5)
+        );
         assert_eq!(token.total_supply(), TokenAmount::from_whole(10));
     }
 }

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -311,6 +311,9 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> FactoryToken<S, BS> {
     }
 
     pub fn token(&mut self) -> Token<'_, S, BS> {
+        // NOTE: cloning an ActorRuntime when using a MemoryBlockstore will lead to changes disappearing as it spawns a new, separate blockstore.
+        // use SharedMemoryBlockstore from fvm_actor_utils for unit testing as it shares a single store between cloned instances
+        // fvm_actor_utils::Blockstore is fine too as it's a syscall wrapper that holds no state (so every instance operates on the one underlying store)
         Token::wrap(self.runtime.clone(), self.state.granularity, &mut self.state.token)
     }
 

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -157,7 +157,7 @@ impl FactoryTokenState {
 /// Implementation of the token API in a FVM actor
 ///
 /// Here the Ipld parameter structs are marshalled and passed to the underlying library functions
-impl<SC: Syscalls + Clone, BS: Blockstore + Clone> FRC46Token for FactoryToken<SC, BS> {
+impl<SC: Syscalls, BS: Blockstore> FRC46Token for FactoryToken<SC, BS> {
     type TokenError = RuntimeError;
     fn name(&self) -> String {
         self.state.name.clone()

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -11,10 +11,9 @@ use frc46_token::token::{
     Token, TokenError,
 };
 use fvm_actor_utils::{
-    blockstore::Blockstore as RuntimeBlockstore,
     messaging::MessagingError,
     receiver::ReceiverHookError,
-    syscalls::{fvm_syscalls::FvmSyscalls, NoStateError, Syscalls},
+    syscalls::{NoStateError, Syscalls},
     util::ActorRuntime,
 };
 use fvm_ipld_blockstore::{Block, Blockstore};
@@ -118,8 +117,10 @@ pub struct ConstructorParams {
     pub minter: Address,
 }
 
-pub fn construct_token(params: ConstructorParams) -> Result<u32, RuntimeError> {
-    let runtime = ActorRuntime::<FvmSyscalls, RuntimeBlockstore>::new_fvm_runtime();
+pub fn construct_token<S: Syscalls, BS: Blockstore>(
+    runtime: ActorRuntime<S, BS>,
+    params: ConstructorParams,
+) -> Result<u32, RuntimeError> {
     let minter = runtime.resolve_id(&params.minter)?;
     let token =
         FactoryToken::new(runtime, params.name, params.symbol, params.granularity, Some(minter));

--- a/frc46_factory_token/token_impl/src/lib.rs
+++ b/frc46_factory_token/token_impl/src/lib.rs
@@ -340,7 +340,7 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> FactoryToken<S, BS> {
         // check if the caller matches our authorise mint operator
         // no minter address means minting has been permanently disabled
         let minter = self.state.minter.ok_or(RuntimeError::MintingDisabled)?;
-        let caller_id = self.runtime.caller(); // TODO: may need to add this to ActorRuntime
+        let caller_id = self.runtime.caller();
         if caller_id != minter {
             return Err(RuntimeError::AddressNotAuthorized);
         }
@@ -370,7 +370,7 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> FactoryToken<S, BS> {
         // no minter means minting has already been permanently disabled
         // we return this if already disabled because it will make more sense than failing the address check below
         let minter = self.state.minter.ok_or(RuntimeError::MintingDisabled)?;
-        let caller_id = self.runtime.caller(); // TODO: add this to ActorRuntime
+        let caller_id = self.runtime.caller();
         if caller_id != minter {
             return Err(RuntimeError::AddressNotAuthorized);
         }

--- a/frc46_token/src/token/mod.rs
+++ b/frc46_token/src/token/mod.rs
@@ -39,8 +39,8 @@ type Result<T> = std::result::Result<T, TokenError>;
 /// Holds injectable services to access/interface with IPLD/FVM layer.
 pub struct Token<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     /// Runtime services to interact with the execution environment
     runtime: &'st ActorRuntime<S, BS>,
@@ -55,8 +55,8 @@ where
 
 impl<'st, S, BS> Token<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     /// Creates a new clean token state instance
     ///
@@ -135,8 +135,8 @@ where
 
 impl<'st, S, BS> Token<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     /// Returns the smallest amount of tokens which is indivisible
     ///
@@ -665,8 +665,8 @@ where
 
 impl<'st, S, BS> Token<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     /// Calls the receiver hook, returning the result
     pub fn call_receiver_hook(

--- a/frc46_token/src/token/mod.rs
+++ b/frc46_token/src/token/mod.rs
@@ -39,8 +39,8 @@ type Result<T> = std::result::Result<T, TokenError>;
 /// Holds injectable services to access/interface with IPLD/FVM layer.
 pub struct Token<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     /// Runtime services to interact with the execution environment
     runtime: ActorRuntime<S, BS>,
@@ -55,8 +55,8 @@ where
 
 impl<'st, S, BS> Token<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     /// Creates a new clean token state instance
     ///
@@ -135,8 +135,8 @@ where
 
 impl<'st, S, BS> Token<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     /// Returns the smallest amount of tokens which is indivisible
     ///
@@ -665,8 +665,8 @@ where
 
 impl<'st, S, BS> Token<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     /// Calls the receiver hook, returning the result
     pub fn call_receiver_hook(

--- a/frc53_nft/src/lib.rs
+++ b/frc53_nft/src/lib.rs
@@ -43,8 +43,8 @@ pub type Result<T> = std::result::Result<T, NFTError>;
 /// A helper handle for NFTState that injects services into the state-level operations
 pub struct NFT<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     runtime: ActorRuntime<S, BS>,
     state: &'st mut NFTState,
@@ -52,8 +52,8 @@ where
 
 impl<'st, S, BS> NFT<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     /// Wrap an instance of the state-tree in a handle for higher-level operations
     pub fn wrap(runtime: ActorRuntime<S, BS>, state: &'st mut NFTState) -> Self {
@@ -106,8 +106,8 @@ where
 
 impl<'st, S, BS> NFT<'st, S, BS>
 where
-    S: Syscalls + Clone,
-    BS: Blockstore + Clone,
+    S: Syscalls,
+    BS: Blockstore,
 {
     /// Return the total number of NFTs in circulation from this collection
     pub fn total_supply(&self) -> u64 {

--- a/frc53_nft/src/lib.rs
+++ b/frc53_nft/src/lib.rs
@@ -43,8 +43,8 @@ pub type Result<T> = std::result::Result<T, NFTError>;
 /// A helper handle for NFTState that injects services into the state-level operations
 pub struct NFT<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     runtime: ActorRuntime<S, BS>,
     state: &'st mut NFTState,
@@ -52,8 +52,8 @@ where
 
 impl<'st, S, BS> NFT<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     /// Wrap an instance of the state-tree in a handle for higher-level operations
     pub fn wrap(runtime: ActorRuntime<S, BS>, state: &'st mut NFTState) -> Self {
@@ -106,8 +106,8 @@ where
 
 impl<'st, S, BS> NFT<'st, S, BS>
 where
-    S: Syscalls,
-    BS: Blockstore,
+    S: Syscalls + Clone,
+    BS: Blockstore + Clone,
 {
     /// Return the total number of NFTs in circulation from this collection
     pub fn total_supply(&self) -> u64 {

--- a/fvm_actor_utils/src/lib.rs
+++ b/fvm_actor_utils/src/lib.rs
@@ -3,5 +3,6 @@ pub mod blockstore;
 pub mod messaging;
 pub mod receiver;
 
+pub mod shared_blockstore;
 pub mod syscalls;
 pub mod util;

--- a/fvm_actor_utils/src/shared_blockstore.rs
+++ b/fvm_actor_utils/src/shared_blockstore.rs
@@ -1,0 +1,47 @@
+use std::rc::Rc;
+
+use anyhow::Result;
+use cid::Cid;
+use fvm_ipld_blockstore::MemoryBlockstore;
+
+/// A shared wrapper around MemoryBlockstore
+/// Clones of it will reference the same underlying MemoryBlockstore, allowing for more complex unit testing
+#[derive(Debug, Clone)]
+pub struct SharedMemoryBlockstore {
+    store: Rc<MemoryBlockstore>,
+}
+
+impl SharedMemoryBlockstore {
+    pub fn new() -> Self {
+        Self { store: Rc::new(MemoryBlockstore::new()) }
+    }
+}
+
+impl Default for SharedMemoryBlockstore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// blockstore implementation, passes calls through to the underlying MemoryBlockstore
+impl fvm_ipld_blockstore::Blockstore for SharedMemoryBlockstore {
+    /// Gets the block from the blockstore.
+    fn get(&self, k: &Cid) -> Result<Option<Vec<u8>>> {
+        self.store.get(k)
+    }
+
+    /// Put a block with a pre-computed cid.
+    ///
+    /// If you don't yet know the CID, use put. Some blockstores will re-compute the CID internally
+    /// even if you provide it.
+    ///
+    /// If you _do_ already know the CID, use this method as some blockstores _won't_ recompute it.
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
+        self.store.put_keyed(k, block)
+    }
+
+    /// Checks if the blockstore has the specified block.
+    fn has(&self, k: &Cid) -> Result<bool> {
+        self.store.has(k)
+    }
+}

--- a/fvm_actor_utils/src/syscalls/fake_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fake_syscalls.rs
@@ -17,12 +17,12 @@ pub struct TestMessage {
 
 #[derive(Clone, Default, Debug)]
 pub struct FakeSyscalls {
-    /// The root of the calling actor
+    /// The root of the receiving actor
     pub root: RefCell<Cid>,
-    /// The f0 ID of the calling actor
+    /// The f0 ID of the receiving actor
     pub actor_id: ActorID,
 
-    /// Actor ID to return as caller
+    /// Actor ID to return as caller ID
     pub caller_id: RefCell<ActorID>,
 
     /// A map of addresses that were instantiated in this runtime

--- a/fvm_actor_utils/src/syscalls/fake_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fake_syscalls.rs
@@ -22,6 +22,9 @@ pub struct FakeSyscalls {
     /// The f0 ID of the calling actor
     pub actor_id: ActorID,
 
+    /// Actor ID to return as caller
+    pub caller_id: RefCell<ActorID>,
+
     /// A map of addresses that were instantiated in this runtime
     pub addresses: RefCell<HashMap<Address, ActorID>>,
     /// The next-to-allocate f0 address
@@ -31,6 +34,13 @@ pub struct FakeSyscalls {
     pub last_message: RefCell<Option<TestMessage>>,
     /// Flag to control message success
     pub abort_next_send: RefCell<bool>,
+}
+
+impl FakeSyscalls {
+    /// Set the ActorID returned as caller
+    pub fn set_caller_id(&self, new_id: ActorID) {
+        self.caller_id.replace(new_id);
+    }
 }
 
 impl Syscalls for FakeSyscalls {
@@ -48,11 +58,7 @@ impl Syscalls for FakeSyscalls {
     }
 
     fn caller(&self) -> fvm_shared::ActorID {
-        // TODO: always return a constant value?
-        // this is for unit testing so it'll be a fixed value anyway
-        // maybe it's something we set and store in the FakeSyscalls struct though?
-        // because some methods may check that the caller ID matches a stored ID (eg: minting tokens)
-        1
+        *self.caller_id.borrow()
     }
 
     fn send(

--- a/fvm_actor_utils/src/syscalls/fake_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fake_syscalls.rs
@@ -18,7 +18,7 @@ pub struct TestMessage {
 #[derive(Clone, Default, Debug)]
 pub struct FakeSyscalls {
     /// The root of the calling actor
-    pub root: Cid,
+    pub root: RefCell<Cid>,
     /// The f0 ID of the calling actor
     pub actor_id: ActorID,
 
@@ -35,7 +35,12 @@ pub struct FakeSyscalls {
 
 impl Syscalls for FakeSyscalls {
     fn root(&self) -> Result<Cid, super::NoStateError> {
-        Ok(self.root)
+        Ok(*self.root.borrow())
+    }
+
+    fn set_root(&self, cid: &Cid) -> Result<(), super::NoStateError> {
+        self.root.replace(*cid);
+        Ok(())
     }
 
     fn receiver(&self) -> fvm_shared::ActorID {

--- a/fvm_actor_utils/src/syscalls/fake_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fake_syscalls.rs
@@ -42,6 +42,14 @@ impl Syscalls for FakeSyscalls {
         self.actor_id
     }
 
+    fn caller(&self) -> fvm_shared::ActorID {
+        // TODO: always return a constant value?
+        // this is for unit testing so it'll be a fixed value anyway
+        // maybe it's something we set and store in the FakeSyscalls struct though?
+        // because some methods may check that the caller ID matches a stored ID (eg: minting tokens)
+        1
+    }
+
     fn send(
         &self,
         to: &fvm_shared::address::Address,

--- a/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
@@ -17,6 +17,10 @@ impl Syscalls for FvmSyscalls {
         fvm_sdk::sself::root().map_err(|_| super::NoStateError)
     }
 
+    fn set_root(&self, cid: &cid::Cid) -> Result<(), super::NoStateError> {
+        fvm_sdk::sself::set_root(cid).map_err(|_| super::NoStateError)
+    }
+
     fn receiver(&self) -> fvm_shared::ActorID {
         fvm_sdk::message::receiver()
     }

--- a/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
@@ -21,6 +21,10 @@ impl Syscalls for FvmSyscalls {
         fvm_sdk::message::receiver()
     }
 
+    fn caller(&self) -> fvm_shared::ActorID {
+        fvm_sdk::message::caller()
+    }
+
     fn send(
         &self,
         to: &Address,
@@ -39,7 +43,7 @@ impl Syscalls for FvmSyscalls {
     }
 }
 
-impl<S: Syscalls, BS: Blockstore> ActorRuntime<S, BS> {
+impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
     pub fn new_fvm_runtime() -> ActorRuntime<FvmSyscalls, crate::blockstore::Blockstore> {
         ActorRuntime {
             syscalls: FvmSyscalls::default(),

--- a/fvm_actor_utils/src/syscalls/mod.rs
+++ b/fvm_actor_utils/src/syscalls/mod.rs
@@ -21,6 +21,14 @@ pub trait Syscalls {
     /// `set_root` and after actor deletion).
     fn root(&self) -> Result<Cid, NoStateError>;
 
+    /// Set the actor's state-tree root.
+    ///
+    /// Fails if:
+    ///
+    /// - The new root is not in the actor's "reachable" set.
+    /// - Fails if the actor has been deleted.
+    fn set_root(&self, cid: &Cid) -> Result<(), NoStateError>;
+
     /// Returns the ID address of the actor
     fn receiver(&self) -> ActorID;
 

--- a/fvm_actor_utils/src/syscalls/mod.rs
+++ b/fvm_actor_utils/src/syscalls/mod.rs
@@ -24,6 +24,9 @@ pub trait Syscalls {
     /// Returns the ID address of the actor
     fn receiver(&self) -> ActorID;
 
+    /// Returns the ID address of the calling actor
+    fn caller(&self) -> ActorID;
+
     /// Sends a message to an actor
     fn send(
         &self,

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -116,7 +116,7 @@ impl<S: Syscalls, BS: Blockstore> ActorRuntime<S, BS> {
         Ok(self.syscalls.root().map_err(|_err| NoStateError)?)
     }
 
-    // Set the root cid of the actor's state
+    /// Set the root cid of the actor's state
     pub fn set_root(&self, cid: &Cid) -> ActorResult<()> {
         Ok(self.syscalls.set_root(cid).map_err(|_err| NoStateError)?)
     }

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -27,12 +27,12 @@ type ActorResult<T> = std::result::Result<T, ActorError>;
 /// It provides higher level utilities than raw syscalls for actors to use to interact with the
 /// IPLD layer and the FVM runtime (e.g. messaging other actors)
 #[derive(Clone, Debug)]
-pub struct ActorRuntime<S: Syscalls + Clone, BS: Blockstore + Clone> {
+pub struct ActorRuntime<S: Syscalls, BS: Blockstore> {
     pub syscalls: S,
     pub blockstore: BS,
 }
 
-impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
+impl<S: Syscalls, BS: Blockstore> ActorRuntime<S, BS> {
     pub fn new(syscalls: S, blockstore: BS) -> ActorRuntime<S, BS> {
         ActorRuntime { syscalls, blockstore }
     }
@@ -143,7 +143,7 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
 }
 
 /// Convenience impl encapsulating the blockstore functionality
-impl<S: Syscalls + Clone, BS: Blockstore + Clone> Blockstore for ActorRuntime<S, BS> {
+impl<S: Syscalls, BS: Blockstore> Blockstore for ActorRuntime<S, BS> {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         self.blockstore.get(k)
     }
@@ -153,7 +153,7 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> Blockstore for ActorRuntime<S,
     }
 }
 
-impl<S: Syscalls + Clone, BS: Blockstore + Clone> Messaging for ActorRuntime<S, BS> {
+impl<S: Syscalls, BS: Blockstore> Messaging for ActorRuntime<S, BS> {
     fn send(
         &self,
         to: &Address,

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -3,7 +3,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::METHOD_SEND;
-use fvm_shared::{address::Address, econ::TokenAmount, ActorID};
+use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, ActorID};
 use fvm_shared::{MethodNum, Response};
 use num_traits::Zero;
 use thiserror::Error;
@@ -21,6 +21,14 @@ pub enum ActorError {
 }
 
 type ActorResult<T> = std::result::Result<T, ActorError>;
+
+impl From<&ActorError> for ExitCode {
+    fn from(error: &ActorError) -> Self {
+        match error {
+            ActorError::NoState(_) => ExitCode::USR_NOT_FOUND,
+        }
+    }
+}
 
 /// ActorRuntime provides access to system resources via Syscalls and the Blockstore
 ///

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -97,6 +97,11 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
         Ok(self.syscalls.root().map_err(|_err| NoStateError)?)
     }
 
+    // Set the root cid of the actor's state
+    pub fn set_root(&self, cid: &Cid) -> ActorResult<()> {
+        Ok(self.syscalls.set_root(cid).map_err(|_err| NoStateError)?)
+    }
+
     /// Attempts to compare two addresses, seeing if they would resolve to the same Actor without
     /// actually instantiating accounts for them
     ///

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -45,6 +45,10 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
         self.syscalls.receiver()
     }
 
+    pub fn caller(&self) -> ActorID {
+        self.syscalls.caller()
+    }
+
     /// Sends a message to an actor
     pub fn send(
         &self,

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -26,12 +26,12 @@ type ActorResult<T> = std::result::Result<T, ActorError>;
 /// It provides higher level utilities than raw syscalls for actors to use to interact with the
 /// IPLD layer and the FVM runtime (e.g. messaging other actors)
 #[derive(Clone, Debug)]
-pub struct ActorRuntime<S: Syscalls, BS: Blockstore> {
+pub struct ActorRuntime<S: Syscalls + Clone, BS: Blockstore + Clone> {
     pub syscalls: S,
     pub blockstore: BS,
 }
 
-impl<S: Syscalls, BS: Blockstore> ActorRuntime<S, BS> {
+impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
     pub fn new(syscalls: S, blockstore: BS) -> ActorRuntime<S, BS> {
         ActorRuntime { syscalls, blockstore }
     }
@@ -123,7 +123,7 @@ impl<S: Syscalls, BS: Blockstore> ActorRuntime<S, BS> {
 }
 
 /// Convenience impl encapsulating the blockstore functionality
-impl<S: Syscalls, BS: Blockstore> Blockstore for ActorRuntime<S, BS> {
+impl<S: Syscalls + Clone, BS: Blockstore + Clone> Blockstore for ActorRuntime<S, BS> {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         self.blockstore.get(k)
     }
@@ -133,7 +133,7 @@ impl<S: Syscalls, BS: Blockstore> Blockstore for ActorRuntime<S, BS> {
     }
 }
 
-impl<S: Syscalls, BS: Blockstore> Messaging for ActorRuntime<S, BS> {
+impl<S: Syscalls + Clone, BS: Blockstore + Clone> Messaging for ActorRuntime<S, BS> {
     fn send(
         &self,
         to: &Address,

--- a/fvm_actor_utils/src/util.rs
+++ b/fvm_actor_utils/src/util.rs
@@ -9,6 +9,7 @@ use num_traits::Zero;
 use thiserror::Error;
 
 use crate::messaging::{Messaging, MessagingError, Result as MessagingResult};
+use crate::shared_blockstore::SharedMemoryBlockstore;
 use crate::syscalls::fake_syscalls::FakeSyscalls;
 use crate::syscalls::NoStateError;
 use crate::syscalls::Syscalls;
@@ -36,8 +37,18 @@ impl<S: Syscalls + Clone, BS: Blockstore + Clone> ActorRuntime<S, BS> {
         ActorRuntime { syscalls, blockstore }
     }
 
+    /// Creates a runtime suitable for tests, using mock syscalls and a memory blockstore
     pub fn new_test_runtime() -> ActorRuntime<FakeSyscalls, MemoryBlockstore> {
         ActorRuntime { syscalls: FakeSyscalls::default(), blockstore: MemoryBlockstore::default() }
+    }
+
+    /// Creates a runtime suitable for more complex tests, using mock syscalls and a shared memory blockstore
+    /// Clones of this runtime will reference the same blockstore
+    pub fn new_shared_test_runtime() -> ActorRuntime<FakeSyscalls, SharedMemoryBlockstore> {
+        ActorRuntime {
+            syscalls: FakeSyscalls::default(),
+            blockstore: SharedMemoryBlockstore::new(),
+        }
     }
 
     /// Returns the address of the current actor as an ActorID

--- a/testing/fil_token_integration/actors/basic_token_actor/src/lib.rs
+++ b/testing/fil_token_integration/actors/basic_token_actor/src/lib.rs
@@ -221,7 +221,7 @@ pub fn invoke(params: u32) -> u32 {
             let mut token_state =
                 Token::<FvmSyscalls, Blockstore>::load_state(helper.bs(), &root_cid).unwrap();
 
-            let mut token_actor = BasicToken { util: Token::wrap(helper, 1, &mut token_state) };
+            let mut token_actor = BasicToken { util: Token::wrap(&helper, 1, &mut token_state) };
 
             // Method numbers calculated via fvm_dispatch_tools using CamelCase names derived from
             // the corresponding FRC46Token trait methods.
@@ -320,7 +320,7 @@ pub fn invoke(params: u32) -> u32 {
 fn constructor() -> u32 {
     let helper = ActorRuntime::<FvmSyscalls, Blockstore>::new_fvm_runtime();
     let mut token_state = Token::<FvmSyscalls, Blockstore>::create_state(helper.bs()).unwrap();
-    let mut token = Token::wrap(helper, 1, &mut token_state);
+    let mut token = Token::wrap(&helper, 1, &mut token_state);
     let cid = token.flush().unwrap();
     sdk::sself::set_root(&cid).unwrap();
     NO_DATA_BLOCK_ID

--- a/testing/fil_token_integration/tests/frc46_multi_actor_tests.rs
+++ b/testing/fil_token_integration/tests/frc46_multi_actor_tests.rs
@@ -1,5 +1,5 @@
 use frc42_dispatch::method_hash;
-use frc46_token::token::{state::TokenState, types::TransferReturn};
+use frc46_token::token::types::TransferReturn;
 use fvm_integration_tests::{dummy::DummyExterns, tester::Account};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
@@ -11,7 +11,7 @@ mod common;
 use common::frc46_token_helpers::TokenHelper;
 use common::{construct_tester, TestHelpers};
 use frc46_test_actor::{action, ActionParams, TestAction};
-use token_impl::{ConstructorParams, FactoryToken};
+use token_impl::ConstructorParams;
 
 const FACTORY_TOKEN_ACTOR_WASM: &str =
     "../../target/debug/wbuild/frc46_factory_token/frc46_factory_token.compact.wasm";
@@ -29,16 +29,7 @@ fn frc46_multi_actor_tests() {
 
     let operator: [Account; 1] = tester.create_accounts().unwrap();
 
-    let initial_token_state = FactoryToken {
-        token: TokenState::new(&blockstore).unwrap(),
-        name: String::new(),
-        symbol: String::new(),
-        granularity: 1,
-        minter: None,
-    };
-
-    let token_actor =
-        tester.install_actor_with_state(FACTORY_TOKEN_ACTOR_WASM, 10000, initial_token_state);
+    let token_actor = tester.install_actor_stateless(FACTORY_TOKEN_ACTOR_WASM, 10000);
     // we'll use up to four actors for some of these tests, though most use only two
     let alice = tester.install_actor_stateless(TEST_ACTOR_WASM, 10010);
     let bob = tester.install_actor_stateless(TEST_ACTOR_WASM, 10011);

--- a/testing/fil_token_integration/tests/frc46_single_actor_tests.rs
+++ b/testing/fil_token_integration/tests/frc46_single_actor_tests.rs
@@ -1,5 +1,5 @@
 use frc42_dispatch::method_hash;
-use frc46_token::token::{state::TokenState, types::MintReturn};
+use frc46_token::token::types::MintReturn;
 use fvm_integration_tests::{dummy::DummyExterns, tester::Account};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
@@ -9,7 +9,7 @@ mod common;
 use common::frc46_token_helpers::TokenHelper;
 use common::{construct_tester, TestHelpers};
 use frc46_test_actor::{action, ActionParams, TestAction};
-use token_impl::{ConstructorParams, FactoryToken};
+use token_impl::ConstructorParams;
 
 const FACTORY_TOKEN_ACTOR_WASM: &str =
     "../../target/debug/wbuild/frc46_factory_token/frc46_factory_token.compact.wasm";
@@ -33,17 +33,8 @@ fn frc46_single_actor_tests() {
 
     let operator: [Account; 1] = tester.create_accounts().unwrap();
 
-    let initial_token_state = FactoryToken {
-        token: TokenState::new(&blockstore).unwrap(),
-        name: String::new(),
-        symbol: String::new(),
-        granularity: 1,
-        minter: None,
-    };
-
     // install actors required for our test: a token actor and one instance of the test actor
-    let token_actor =
-        tester.install_actor_with_state(FACTORY_TOKEN_ACTOR_WASM, 10000, initial_token_state);
+    let token_actor = tester.install_actor_stateless(FACTORY_TOKEN_ACTOR_WASM, 10000);
     let frc46_test_actor = tester.install_actor_stateless(TEST_ACTOR_WASM, 10010);
 
     // Instantiate machine


### PR DESCRIPTION
This started out when I wanted to add some unit test coverage to `token_impl` for the factory token, and update it to use the `ActorRuntime` instead of raw syscalls. While doing this, I kept running into walls where the runtime was missing something I needed or (in the most annoying case) that I can't clone or share the thing around as I needed.

Summary of changes:
- ~~made `ActorRuntime` clone()-able (which required adding the trait bound everywhere)~~  replaced by making FRC46 `Token`take a reference to the `ActorRuntime` instead of owning it
- added `SharedMemoryBlockstore` wrapper for a ref-counted `MemoryBlockstore` we can clone and share with other runtime instances (for cloning when a temporary `Token` handle needs it)
- added caller ID to `ActorRuntime` including a method to set it in `FakeSyscalls` for unit testing
- added `set_root` to `ActorRuntime` so there's no need for raw syscalls when saving state and updating the root CID
- most of the `FactoryToken` implementation is now covered by unit tests (which pass param structs and use a fake runtime so they're closer to how the integration tests work, it's not a total repeat of everything we already cover in `frc46_token`)