### PR TITLE
More FRC46 integration tests

### DIFF
--- a/testing/fil_token_integration/tests/common/frc46_token_helpers.rs
+++ b/testing/fil_token_integration/tests/common/frc46_token_helpers.rs
@@ -65,6 +65,17 @@ pub trait TokenHelper {
         token_actor: Address,
         target: Address,
     );
+
+    /// Get total supply of tokens
+    fn total_supply(&mut self, operator: Address, token_actor: Address) -> TokenAmount;
+
+    /// Check total supply, asserting that it matches the given amount
+    fn assert_total_supply(
+        &mut self,
+        operator: Address,
+        token_actor: Address,
+        total_supply: TokenAmount,
+    );
 }
 
 impl<B: Blockstore, E: Externs> TokenHelper for Tester<B, E> {
@@ -125,5 +136,20 @@ impl<B: Blockstore, E: Externs> TokenHelper for Tester<B, E> {
     ) {
         let balance = self.token_balance(operator, token_actor, target);
         assert_eq!(balance, TokenAmount::zero());
+    }
+
+    fn total_supply(&mut self, operator: Address, token_actor: Address) -> TokenAmount {
+        let ret_val = self.call_method(operator, token_actor, method_hash!("TotalSupply"), None);
+        ret_val.msg_receipt.return_data.deserialize::<TokenAmount>().unwrap()
+    }
+
+    fn assert_total_supply(
+        &mut self,
+        operator: Address,
+        token_actor: Address,
+        total_supply: TokenAmount,
+    ) {
+        let supply = self.total_supply(operator, token_actor);
+        assert_eq!(supply, total_supply);
     }
 }

--- a/testing/fil_token_integration/tests/frc46_multi_actor_tests.rs
+++ b/testing/fil_token_integration/tests/frc46_multi_actor_tests.rs
@@ -295,4 +295,34 @@ fn frc46_multi_actor_tests() {
         tester.assert_token_balance_zero(operator[0].1, token_actor, alice);
         tester.assert_token_balance(operator[0].1, token_actor, bob, TokenAmount::from_atto(300));
     }
+
+    // TEST: alice transfers to bob, bob's hook burns but then aborts
+    {
+        // mint some more to alice first
+        tester.mint_tokens_ok(
+            operator[0].1,
+            token_actor,
+            alice,
+            TokenAmount::from_atto(100),
+            action(TestAction::Accept),
+        );
+        let params = action_params(
+            token_actor,
+            TestAction::Transfer(
+                bob,
+                action(TestAction::ActionThenAbort(action(TestAction::Burn))),
+            ),
+        );
+        let ret_val =
+            tester.call_method_ok(operator[0].1, alice, method_hash!("Action"), Some(params));
+        // check the receipt we got in return data
+        let receipt: Receipt = ret_val.msg_receipt.return_data.deserialize().unwrap();
+        assert_eq!(receipt.exit_code, ExitCode::USR_UNSPECIFIED);
+
+        // check balances - alice should keep the 100 we just minted, bob remains at 300
+        tester.assert_token_balance(operator[0].1, token_actor, alice, TokenAmount::from_atto(100));
+        tester.assert_token_balance(operator[0].1, token_actor, bob, TokenAmount::from_atto(300));
+        // total supply should be 500 - 100 each for alice and carol, 300 for bob
+        tester.assert_total_supply(operator[0].1, token_actor, TokenAmount::from_atto(500));
+    }
 }

--- a/testing/fil_token_integration/tests/frc46_single_actor_tests.rs
+++ b/testing/fil_token_integration/tests/frc46_single_actor_tests.rs
@@ -208,4 +208,27 @@ fn frc46_single_actor_tests() {
             TokenAmount::from_atto(100),
         );
     }
+
+    // TEST: test actor transfers to self (non-zero amount) and rejects
+    {
+        let test_action = ActionParams {
+            token_address: token_actor,
+            action: TestAction::Transfer(frc46_test_actor, action(TestAction::Reject)),
+        };
+        let params = RawBytes::serialize(test_action).unwrap();
+        tester.call_method_ok(
+            operator[0].1,
+            frc46_test_actor,
+            method_hash!("Action"),
+            Some(params),
+        );
+
+        // check that our test actor balance hasn't changed
+        tester.assert_token_balance(
+            operator[0].1,
+            token_actor,
+            frc46_test_actor,
+            TokenAmount::from_atto(100),
+        );
+    }
 }


### PR DESCRIPTION
Fills in the missing pieces from #80 and adds a few enhancements to the test actor and test helper traits
- [x] A transfers to A and rejects hook
- [x] A transfer to B, hook transfer to C (rejected), B hook then transfers to D
- [x] A transfer to B, hook transfer back to A (accept / reject)
- [x] A transfer to B, hook burns but then aborts (tokens don't move)
- [x] A transfer to B, hook transfer to C, but then B hook aborts (no move)