### PR TITLE
Release/fvm v3.1

### DIFF
--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -8,11 +8,11 @@ frc42_dispatch = { path = "../../frc42_dispatch" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 
 [dev-dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm = { version = "~3.0", default-features = false }
+fvm = { version = "^3.0.0", default-features = false }
 fvm_integration_tests = "~3.0"
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "09aa10f082565565b08572532b245236525f778c" }
 

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 fvm_ipld_encoding = { version = "~0.3" }
 fvm_sdk = { version = "~3.0", optional = true }
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 frc42_hasher = { version = "1.2.0", path = "hasher" }
 frc42_macros = { version = "1.0.0", path = "macros" }
 thiserror = { version = "1.0.31" }

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "3.0.1"
+version = "3.1.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -12,8 +12,8 @@ edition = "2021"
 fvm_ipld_encoding = { version = "~0.3" }
 fvm_sdk = { version = "~3.0", optional = true }
 fvm_shared = "~3.1"
-frc42_hasher = { version = "1.2.0", path = "hasher" }
-frc42_macros = { version = "1.0.0", path = "macros" }
+frc42_hasher = { version = "1.4.0", path = "hasher" }
+frc42_macros = { version = "1.1.0", path = "macros" }
 thiserror = { version = "1.0.31" }
 
 [features]

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_hasher"
-version = "1.3.0"
+version = "1.4.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 fvm_sdk = { version = "~3.0", optional = true }
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 thiserror = { version = "1.0.31" }
 
 [features]

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_macros"
-version = "1.0.0"
+version = "1.1.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention procedural macros"
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-frc42_hasher = { version = "1.2.0", path = "../hasher", features = ["no_sdk"] }
+frc42_hasher = { version = "1.4.0", path = "../hasher", features = ["no_sdk"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/frc46_factory_token/Cargo.toml
+++ b/frc46_factory_token/Cargo.toml
@@ -11,7 +11,7 @@ fvm_actor_utils = { path = "../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
@@ -19,7 +19,7 @@ token_impl = { path = "token_impl" }
 
 [dev-dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm = { version = "3.0.0", default-features = false }
+fvm = { version = "^3.0.0", default-features = false }
 fvm_integration_tests = "~3.0"
 frc46_test_actor = { path = "../testing/fil_token_integration/actors/frc46_test_actor" }
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", rev = "09aa10f082565565b08572532b245236525f778c" }

--- a/frc46_factory_token/token_impl/Cargo.toml
+++ b/frc46_factory_token/token_impl/Cargo.toml
@@ -12,7 +12,7 @@ fvm_actor_utils = { path = "../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -18,7 +18,7 @@ fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "4.0.1"
+version = "5.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
-frc42_dispatch = { version = "3.0.1", path = "../frc42_dispatch" }
-fvm_actor_utils = { version = "4.0.1", path = "../fvm_actor_utils" }
+frc42_dispatch = { version = "3.1.0", path = "../frc42_dispatch" }
+fvm_actor_utils = { version = "5.0.0", path = "../fvm_actor_utils" }
 
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -15,7 +15,7 @@ fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 integer-encoding = { version = "3.0.4" }
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
-fvm_shared = "~3.0"
+fvm_shared = "~3.1"
 fvm_sdk = "~3.0"
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "fvm_actor_utils"
 description = "Utils for authoring native actors for the Filecoin Virtual Machine"
-version = "4.0.1"
+version = "5.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm"]
 repository = "https://github.com/helix-onchain/filecoin/"
 edition = "2021"
 
 [dependencies]
-frc42_dispatch = { version = "3.0.1", path = "../frc42_dispatch" }
+frc42_dispatch = { version = "3.1.0", path = "../frc42_dispatch" }
 
 anyhow = "1.0.56"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/testing/fil_token_integration/Cargo.toml
+++ b/testing/fil_token_integration/Cargo.toml
@@ -12,11 +12,11 @@ token_impl = { path = "../../frc46_factory_token/token_impl" }
 
 anyhow = { version = "1.0.63", features = ["backtrace"] }
 cid = { version = "0.8.5", default-features = false }
-fvm = { version = "3.0.0", default-features = false }
+fvm = { version = "^3.0.0", default-features = false }
 fvm_integration_tests = "~3.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 

--- a/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_nft_actor/Cargo.toml
@@ -12,7 +12,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }

--- a/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_receiving_actor/Cargo.toml
@@ -12,7 +12,7 @@ fvm_actor_utils = { path = "../../../../fvm_actor_utils" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 
 [build-dependencies]
 substrate-wasm-builder = "4.0"

--- a/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_token_actor/Cargo.toml
@@ -12,7 +12,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }

--- a/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/basic_transfer_actor/Cargo.toml
@@ -12,7 +12,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 

--- a/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frc46_test_actor/Cargo.toml
@@ -13,7 +13,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 

--- a/testing/fil_token_integration/actors/frc53_test_actor/Cargo.toml
+++ b/testing/fil_token_integration/actors/frc53_test_actor/Cargo.toml
@@ -13,7 +13,7 @@ cid = { version = "0.8.5", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1" }
 fvm_ipld_encoding = "~0.3"
 fvm_sdk = "~3.0"
-fvm_shared = { version = "~3.0" }
+fvm_shared = "~3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 


### PR DESCRIPTION
These have already been published and tagged off of this branch but the mainline version numbers should be brought up to date with this latest branch.