### PR TITLE
make `fvm_sdk` and `fvm_shared` optional in `frc42_hasher`

### DIFF
--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 
 [dependencies]
 fvm_sdk = { version = "~3.2", optional = true }
-fvm_shared = "~3.2"
+fvm_shared = { version = "~3.2", optional = true }
 thiserror = { version = "1.0.31" }
 
 [features]
-default = ["dep:fvm_sdk"]
+default = ["dep:fvm_sdk", "dep:fvm_shared"]
 no_sdk = [] # avoid dependence on fvm_sdk (for proc macro and similar purposes)

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-frc42_hasher = { version = "1.5.0", path = "../hasher", features = ["no_sdk"] }
+frc42_hasher = { version = "1.5.0", path = "../hasher", default-features = false, features = ["no_sdk"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
`frc42_macros` should not depend on `fvm_sdk` and `fvm_shared`.

Here's `cargo tree` after the PR:
```
frc42_macros v1.2.0 (proc-macro) (/home/lemmih/coding/filecoin/frc42_dispatch/macros)
├── blake2b_simd v1.0.1
│   ├── arrayref v0.3.7
│   ├── arrayvec v0.7.4
│   └── constant_time_eq v0.2.6
├── frc42_hasher v1.5.0 (/home/lemmih/coding/filecoin/frc42_dispatch/hasher)
│   └── thiserror v1.0.40
│       └── thiserror-impl v1.0.40 (proc-macro)
│           ├── proc-macro2 v1.0.63
│           │   └── unicode-ident v1.0.9
│           ├── quote v1.0.29
│           │   └── proc-macro2 v1.0.63 (*)
│           └── syn v2.0.22
│               ├── proc-macro2 v1.0.63 (*)
│               ├── quote v1.0.29 (*)
│               └── unicode-ident v1.0.9
├── proc-macro2 v1.0.63 (*)
├── quote v1.0.29 (*)
└── syn v1.0.109
    ├── proc-macro2 v1.0.63 (*)
    ├── quote v1.0.29 (*)
    └── unicode-ident v1.0.9
```

Here's `cargo tree` before the PR:
```
frc42_macros v1.2.0 (proc-macro) (/home/lemmih/coding/filecoin/frc42_dispatch/macros)
├── blake2b_simd v1.0.1
│   ├── arrayref v0.3.7
│   ├── arrayvec v0.7.4
│   └── constant_time_eq v0.2.6
├── frc42_hasher v1.5.0 (/home/lemmih/coding/filecoin/frc42_dispatch/hasher)
│   ├── fvm_sdk v3.2.0
│   │   ├── cid v0.8.6
│   │   │   ├── core2 v0.4.0
│   │   │   │   └── memchr v2.5.0
│   │   │   ├── multibase v0.9.1
│   │   │   │   ├── base-x v0.2.11
│   │   │   │   ├── data-encoding v2.4.0
│   │   │   │   └── data-encoding-macro v0.1.13
│   │   │   │       ├── data-encoding v2.4.0
│   │   │   │       └── data-encoding-macro-internal v0.1.11 (proc-macro)
│   │   │   │           ├── data-encoding v2.4.0
│   │   │   │           └── syn v1.0.109
│   │   │   │               ├── proc-macro2 v1.0.63
│   │   │   │               │   └── unicode-ident v1.0.9
│   │   │   │               ├── quote v1.0.29
│   │   │   │               │   └── proc-macro2 v1.0.63 (*)
│   │   │   │               └── unicode-ident v1.0.9
│   │   │   ├── multihash v0.16.3
│   │   │   │   ├── blake2b_simd v1.0.1 (*)
│   │   │   │   ├── core2 v0.4.0 (*)
│   │   │   │   ├── digest v0.10.7
│   │   │   │   │   ├── block-buffer v0.10.4
│   │   │   │   │   │   └── generic-array v0.14.7
│   │   │   │   │   │       └── typenum v1.16.0
│   │   │   │   │   │       [build-dependencies]
│   │   │   │   │   │       └── version_check v0.9.4
│   │   │   │   │   └── crypto-common v0.1.6
│   │   │   │   │       ├── generic-array v0.14.7 (*)
│   │   │   │   │       └── typenum v1.16.0
│   │   │   │   ├── multihash-derive v0.8.1 (proc-macro)
│   │   │   │   │   ├── proc-macro-crate v1.1.3
│   │   │   │   │   │   ├── thiserror v1.0.40
│   │   │   │   │   │   │   └── thiserror-impl v1.0.40 (proc-macro)
│   │   │   │   │   │   │       ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │   │   │       ├── quote v1.0.29 (*)
│   │   │   │   │   │   │       └── syn v2.0.22
│   │   │   │   │   │   │           ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │   │   │           ├── quote v1.0.29 (*)
│   │   │   │   │   │   │           └── unicode-ident v1.0.9
│   │   │   │   │   │   └── toml v0.5.11
│   │   │   │   │   │       └── serde v1.0.164
│   │   │   │   │   │           └── serde_derive v1.0.164 (proc-macro)
│   │   │   │   │   │               ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │   │               ├── quote v1.0.29 (*)
│   │   │   │   │   │               └── syn v2.0.22 (*)
│   │   │   │   │   ├── proc-macro-error v1.0.4
│   │   │   │   │   │   ├── proc-macro-error-attr v1.0.4 (proc-macro)
│   │   │   │   │   │   │   ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │   │   │   └── quote v1.0.29 (*)
│   │   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   │   └── version_check v0.9.4
│   │   │   │   │   │   ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │   │   ├── quote v1.0.29 (*)
│   │   │   │   │   │   └── syn v1.0.109 (*)
│   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   └── version_check v0.9.4
│   │   │   │   │   ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │   ├── quote v1.0.29 (*)
│   │   │   │   │   ├── syn v1.0.109 (*)
│   │   │   │   │   └── synstructure v0.12.6
│   │   │   │   │       ├── proc-macro2 v1.0.63 (*)
│   │   │   │   │       ├── quote v1.0.29 (*)
│   │   │   │   │       ├── syn v1.0.109 (*)
│   │   │   │   │       └── unicode-xid v0.2.4
│   │   │   │   ├── ripemd v0.1.3
│   │   │   │   │   └── digest v0.10.7 (*)
│   │   │   │   ├── serde v1.0.164 (*)
│   │   │   │   ├── serde-big-array v0.3.3
│   │   │   │   │   └── serde v1.0.164 (*)
│   │   │   │   ├── sha2 v0.10.7
│   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   ├── cpufeatures v0.2.8
│   │   │   │   │   └── digest v0.10.7 (*)
│   │   │   │   ├── sha3 v0.10.8
│   │   │   │   │   ├── digest v0.10.7 (*)
│   │   │   │   │   └── keccak v0.1.4
│   │   │   │   └── unsigned-varint v0.7.1
│   │   │   ├── serde v1.0.164 (*)
│   │   │   ├── serde_bytes v0.11.9
│   │   │   │   └── serde v1.0.164 (*)
│   │   │   └── unsigned-varint v0.7.1
│   │   ├── fvm_ipld_encoding v0.3.3
│   │   │   ├── anyhow v1.0.71
│   │   │   ├── cid v0.8.6 (*)
│   │   │   ├── fvm_ipld_blockstore v0.1.2
│   │   │   │   ├── anyhow v1.0.71
│   │   │   │   ├── cid v0.8.6 (*)
│   │   │   │   └── multihash v0.16.3 (*)
│   │   │   ├── multihash v0.16.3 (*)
│   │   │   ├── serde v1.0.164 (*)
│   │   │   ├── serde_ipld_dagcbor v0.2.2
│   │   │   │   ├── cbor4ii v0.2.14
│   │   │   │   │   └── serde v1.0.164 (*)
│   │   │   │   ├── cid v0.8.6 (*)
│   │   │   │   ├── scopeguard v1.1.0
│   │   │   │   └── serde v1.0.164 (*)
│   │   │   ├── serde_repr v0.1.12 (proc-macro)
│   │   │   │   ├── proc-macro2 v1.0.63 (*)
│   │   │   │   ├── quote v1.0.29 (*)
│   │   │   │   └── syn v2.0.22 (*)
│   │   │   ├── serde_tuple v0.5.0
│   │   │   │   ├── serde v1.0.164 (*)
│   │   │   │   └── serde_tuple_macros v0.5.0 (proc-macro)
│   │   │   │       ├── proc-macro2 v1.0.63 (*)
│   │   │   │       ├── quote v1.0.29 (*)
│   │   │   │       └── syn v1.0.109 (*)
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── fvm_shared v3.2.0
│   │   │   ├── anyhow v1.0.71
│   │   │   ├── bitflags v1.3.2
│   │   │   ├── blake2b_simd v1.0.1 (*)
│   │   │   ├── cid v0.8.6 (*)
│   │   │   ├── data-encoding v2.4.0
│   │   │   ├── data-encoding-macro v0.1.13 (*)
│   │   │   ├── fvm_ipld_encoding v0.3.3 (*)
│   │   │   ├── lazy_static v1.4.0
│   │   │   ├── multihash v0.16.3 (*)
│   │   │   ├── num-bigint v0.4.3
│   │   │   │   ├── num-integer v0.1.45
│   │   │   │   │   └── num-traits v0.2.15
│   │   │   │   │       [build-dependencies]
│   │   │   │   │       └── autocfg v1.1.0
│   │   │   │   │   [build-dependencies]
│   │   │   │   │   └── autocfg v1.1.0
│   │   │   │   └── num-traits v0.2.15 (*)
│   │   │   │   [build-dependencies]
│   │   │   │   └── autocfg v1.1.0
│   │   │   ├── num-derive v0.3.3 (proc-macro)
│   │   │   │   ├── proc-macro2 v1.0.63 (*)
│   │   │   │   ├── quote v1.0.29 (*)
│   │   │   │   └── syn v1.0.109 (*)
│   │   │   ├── num-integer v0.1.45 (*)
│   │   │   ├── num-traits v0.2.15 (*)
│   │   │   ├── serde v1.0.164 (*)
│   │   │   ├── serde_tuple v0.5.0 (*)
│   │   │   ├── thiserror v1.0.40 (*)
│   │   │   └── unsigned-varint v0.7.1
│   │   ├── lazy_static v1.4.0
│   │   ├── log v0.4.19
│   │   ├── num-traits v0.2.15 (*)
│   │   └── thiserror v1.0.40 (*)
│   ├── fvm_shared v3.2.0 (*)
│   └── thiserror v1.0.40 (*)
├── proc-macro2 v1.0.63 (*)
├── quote v1.0.29 (*)
└── syn v1.0.109 (*)
```