### PR TITLE
remove go-interop feat from AMT crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "3.2.12", features = ["derive"] }
 cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
 fvm = { version = "^3.0.0", default-features = false }
 fvm_integration_tests = "~3.1.0"
-fvm_ipld_amt = { version = "0.6.0", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.6.0" }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.2.0"
 fvm_ipld_encoding = "0.4.0"


### PR DESCRIPTION
Based on the discussion in https://github.com/filecoin-project/ref-fvm/issues/1856, the feature will disappear and should not be used anymore.