### PR TITLE
chore: update fvm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "dispatch_examples/greeter",
     "frc42_dispatch",
@@ -18,21 +18,21 @@ members = [
 
 [workspace.dependencies]
 blake2b_simd = { version = "1.0.0" }
-clap = { version = "3.2.12", features = ["derive"] }
+clap = { version = "4.3.21", features = ["derive"] }
 cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
 fvm = { version = "^3.0.0", default-features = false }
-fvm_integration_tests = "~3.1.0"
-fvm_ipld_amt = { version = "0.6.0" }
-fvm_ipld_bitfield = "0.5.4"
+fvm_integration_tests = "~3.2.0"
+fvm_ipld_amt = "0.6.0"
+fvm_ipld_bitfield = "0.6.0"
 fvm_ipld_blockstore = "0.2.0"
 fvm_ipld_encoding = "0.4.0"
 fvm_ipld_hamt = "0.7.0"
 fvm_sdk = "~3.3.0"
-fvm_shared = "~3.4.0"
+fvm_shared = "~3.6.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
-integer-encoding = { version = "3.0.4" }
+integer-encoding = { version = "4.0.0" }
 num-traits = { version = "0.2.15" }
 anyhow = { version = "1.0.56" }
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -22,6 +22,6 @@ serde = { workspace = true }
 serde_tuple = { workspace = true }
 
 [dev-dependencies]
-actors-v12 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors" }
+actors-v12 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "chore/update-fvm" }
 helix_test_actors = { path = "../test_actors" }
 token_impl = { path = "../test_actors/actors/frc46_factory_token/token_impl" }


### PR DESCRIPTION
Also updates a few deps and switches to resolver-v2 (because cargo was complaining about that).

Replaces https://github.com/helix-onchain/filecoin/pull/219