### PR TITLE
chore: release crates for FVM update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ num-traits = { version = "0.2.15" }
 anyhow = { version = "1.0.56" }
 
 # internal deps of published packages
-frc42_dispatch = { version = "3.3.0", path = "./frc42_dispatch", default-features=false }
-fvm_actor_utils = { version = "7.0.0", path = "./fvm_actor_utils" }
+frc42_dispatch = { version = "4.0.0", path = "./frc42_dispatch", default-features=false }
+fvm_actor_utils = { version = "8.0.0", path = "./fvm_actor_utils" }
 
 # only consumed by non-published packages
 frc53_nft = { path = "./frc53_nft" }

--- a/dispatch_examples/greeter/Cargo.toml
+++ b/dispatch_examples/greeter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "greeter"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "3.3.0"
+version = "4.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -12,8 +12,8 @@ edition = "2021"
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true, optional = true }
 fvm_shared = { workspace = true }
-frc42_hasher = { version = "1.6.0", path = "hasher" }
-frc42_macros = { version = "1.3.0", path = "macros" }
+frc42_hasher = { version = "2.0.0", path = "hasher" }
+frc42_macros = { version = "2.0.0", path = "macros" }
 thiserror = { version = "1.0.31" }
 
 [features]

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_hasher"
-version = "1.6.0"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_macros"
-version = "1.3.0"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention procedural macros"
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-frc42_hasher = { version = "1.6.0", path = "../hasher", default-features = false }
+frc42_hasher = { version = "2.0.0", path = "../hasher", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/frc42_dispatch/macros/example/Cargo.toml
+++ b/frc42_dispatch/macros/example/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
-frc42_macros = { version = "1.0.0", path = ".." }
+frc42_macros = { version = "2.0.0", path = ".." }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "7.0.0"
+version = "8.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "frc53_nft"
 description = "Filecoin FRC-0053 non-fungible token reference implementation"
-version = "1.0.0"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "nft", "frc-0053"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_actor_utils"
 description = "Utils for authoring native actors for the Filecoin Virtual Machine"
-version = "7.0.0"
+version = "8.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -3,6 +3,7 @@ name = "helix_integration_tests"
 version = "0.1.0"
 repository = "https://github.com/helix-collective/filecoin"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/testing/test_actors/actors/basic_nft_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_nft_actor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "basic_nft_actor"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/testing/test_actors/actors/basic_receiving_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_receiving_actor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "basic_receiving_actor"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/testing/test_actors/actors/basic_token_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_token_actor/Cargo.toml
@@ -3,6 +3,7 @@ name = "basic_token_actor"
 version = "0.1.0"
 repository = "https://github.com/helix-collective/filecoin"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc46_token = { path = "../../../../frc46_token" }

--- a/testing/test_actors/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_transfer_actor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "basic_transfer_actor"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/testing/test_actors/actors/frc46_factory_token/Cargo.toml
+++ b/testing/test_actors/actors/frc46_factory_token/Cargo.toml
@@ -2,6 +2,7 @@
 name = "frc46_factory_token"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 cid = { workspace = true }

--- a/testing/test_actors/actors/frc46_test_actor/Cargo.toml
+++ b/testing/test_actors/actors/frc46_test_actor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "frc46_test_actor"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc46_token = { workspace = true }

--- a/testing/test_actors/actors/frc53_test_actor/Cargo.toml
+++ b/testing/test_actors/actors/frc53_test_actor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "frc53_test_actor"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frc46_token = { workspace = true }


### PR DESCRIPTION
I've also marked some test crates as "don't publish" to make it easier to see what needs to be released.

This patch releases:

- frc42_dispatch 4.0.0
- frc42_hasher 2.0.0
- frc46_token 8.0.0
- frc53_nft 2.0.0
- fvm_actor_utils 8.0.0
- frc42_macros 2.0.0